### PR TITLE
feat: Add VFS abstraction layer for cloud storage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ add_library(flapi-lib STATIC
     src/config_token_utils.cpp
     src/error.cpp
     src/type_converter.cpp
+    src/vfs_adapter.cpp
 )
 
 # Ensure web_ui is built before flapi-lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,7 @@ add_library(flapi-lib STATIC
     src/error.cpp
     src/type_converter.cpp
     src/vfs_adapter.cpp
+    src/path_validator.cpp
 )
 
 # Ensure web_ui is built before flapi-lib

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,12 @@ integration-test-examples: release integration-test-setup
 integration-test-ci: release integration-test-setup
 	@echo "Running integration tests with server management..."
 	@echo "Starting flapi server in background..."
-	@$(RELEASE_DIR)/flapi --config examples/flapi.yaml --log-level info & \
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		FLAPI_BIN=$(BUILD_DIR)/universal/flapi; \
+	else \
+		FLAPI_BIN=$(RELEASE_DIR)/flapi; \
+	fi; \
+	$$FLAPI_BIN --config examples/flapi.yaml --log-level info & \
 	SERVER_PID=$$!; \
 	echo "Server started with PID: $$SERVER_PID"; \
 	sleep 5; \

--- a/docs/CLOUD_STORAGE_GUIDE.md
+++ b/docs/CLOUD_STORAGE_GUIDE.md
@@ -1,0 +1,375 @@
+# Cloud Storage Guide
+
+This guide explains how to use flAPI with cloud storage backends (S3, GCS, Azure, HTTPS) for configuration files and SQL templates.
+
+## Overview
+
+flAPI supports loading configuration and SQL template files from remote storage via DuckDB's Virtual File System (VFS). This enables:
+
+- **Serverless deployments**: Run flAPI on AWS Lambda, Google Cloud Run, or Azure Functions without volume mounts
+- **Centralized configuration**: Store all endpoint definitions in a single S3 bucket or GCS bucket
+- **GitOps workflows**: Deploy configuration changes by updating files in cloud storage
+- **Multi-environment setups**: Use different storage paths for dev/staging/prod
+
+## Quick Start
+
+### Loading Config from HTTPS
+
+The simplest way to use remote configuration is via HTTPS:
+
+```bash
+flapi --config https://raw.githubusercontent.com/myorg/configs/main/flapi.yaml
+```
+
+### Loading Config from S3
+
+For S3, set AWS credentials and use an S3 URL:
+
+```bash
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+export AWS_REGION=us-east-1
+
+flapi --config s3://my-bucket/configs/flapi.yaml
+```
+
+### Loading Config from GCS
+
+For Google Cloud Storage:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+flapi --config gs://my-bucket/configs/flapi.yaml
+```
+
+## Supported Storage Backends
+
+| Backend | URL Scheme | Authentication |
+|---------|------------|----------------|
+| Amazon S3 | `s3://` | AWS credentials (env vars or IAM role) |
+| S3-compatible | `s3://`, `s3a://`, `s3n://` | Same as S3 |
+| Google Cloud Storage | `gs://` | Service account or ADC |
+| Azure Blob Storage | `az://`, `abfs://` | Storage account key or managed identity |
+| HTTPS | `https://` | None (public) or HTTP auth headers |
+| HTTP | `http://` | None (not recommended for production) |
+| Local filesystem | `file://` or plain path | Filesystem permissions |
+
+## Configuration Examples
+
+### Example 1: HTTPS Templates
+
+Load templates from a web server or GitHub raw URLs:
+
+```yaml
+# flapi.yaml
+project-name: HTTPS Example
+project-description: Templates served via HTTPS
+
+template:
+  path: https://raw.githubusercontent.com/myorg/templates/main/sqls/
+
+connections:
+  local-data:
+    properties:
+      path: ./data/customers.parquet
+```
+
+### Example 2: S3 Configuration
+
+Full configuration with S3 for both config and templates:
+
+```yaml
+# flapi.yaml (can be hosted at s3://my-bucket/configs/flapi.yaml)
+project-name: S3 Cloud API
+project-description: Fully cloud-native configuration
+
+template:
+  path: s3://my-bucket/templates/
+
+connections:
+  s3-data:
+    init: |
+      INSTALL httpfs;
+      LOAD httpfs;
+      SET s3_region='us-east-1';
+    properties:
+      bucket: my-data-bucket
+      base_path: s3://my-data-bucket/data/
+
+duckdb:
+  access_mode: READ_ONLY
+```
+
+### Example 3: Mixed Local/Remote
+
+Use local config with remote templates:
+
+```yaml
+# flapi.yaml (local)
+project-name: Mixed Storage API
+project-description: Local config, remote templates
+
+template:
+  path: https://templates.example.com/sqls/
+
+connections:
+  local-parquet:
+    properties:
+      path: ./data/customers.parquet
+```
+
+### Example 4: Remote Template in Endpoint
+
+Specify remote templates per-endpoint:
+
+```yaml
+# sqls/customers.yaml
+url-path: /customers
+method: GET
+
+# Remote template - full URL overrides template.path
+template-source: https://templates.example.com/customers.sql
+
+connection:
+  - local-data
+```
+
+## Authentication
+
+### Amazon S3
+
+**Option 1: Environment Variables**
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_REGION=us-east-1
+
+# Optional: for temporary credentials
+export AWS_SESSION_TOKEN=your-session-token
+```
+
+**Option 2: IAM Role (EC2/ECS/Lambda)**
+
+When running on AWS infrastructure, flAPI automatically uses the instance's IAM role. No environment variables needed.
+
+**Option 3: AWS Profile**
+
+```bash
+export AWS_PROFILE=my-profile
+```
+
+### Google Cloud Storage
+
+**Option 1: Service Account Key**
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+**Option 2: Application Default Credentials**
+
+```bash
+gcloud auth application-default login
+```
+
+**Option 3: Compute Engine/Cloud Run**
+
+Uses the attached service account automatically.
+
+### Azure Blob Storage
+
+**Option 1: Storage Account Key**
+
+```bash
+export AZURE_STORAGE_ACCOUNT=mystorageaccount
+export AZURE_STORAGE_KEY=your-storage-key
+```
+
+**Option 2: Connection String**
+
+```bash
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;..."
+```
+
+**Option 3: Managed Identity**
+
+When running on Azure infrastructure, uses the managed identity automatically.
+
+## Serverless Deployment
+
+### AWS Lambda
+
+```dockerfile
+FROM public.ecr.aws/lambda/provided:al2
+
+COPY flapi /var/task/
+COPY bootstrap /var/task/
+
+# Config loaded from S3 at runtime
+ENV FLAPI_CONFIG=s3://my-bucket/configs/flapi.yaml
+ENV AWS_REGION=us-east-1
+
+CMD ["flapi"]
+```
+
+```bash
+# bootstrap script
+#!/bin/sh
+exec /var/task/flapi --config "$FLAPI_CONFIG"
+```
+
+### Google Cloud Run
+
+```dockerfile
+FROM gcr.io/distroless/cc
+
+COPY flapi /flapi
+
+# Config loaded from GCS at runtime
+ENV FLAPI_CONFIG=gs://my-bucket/configs/flapi.yaml
+
+ENTRYPOINT ["/flapi", "--config", "${FLAPI_CONFIG}"]
+```
+
+### Azure Container Apps
+
+```yaml
+# container-app.yaml
+properties:
+  configuration:
+    secrets:
+      - name: azure-storage-key
+        value: your-storage-key
+  template:
+    containers:
+      - name: flapi
+        image: myregistry.azurecr.io/flapi:latest
+        env:
+          - name: FLAPI_CONFIG
+            value: az://my-container/configs/flapi.yaml
+          - name: AZURE_STORAGE_ACCOUNT
+            value: mystorageaccount
+          - name: AZURE_STORAGE_KEY
+            secretRef: azure-storage-key
+```
+
+## Security Best Practices
+
+### 1. Use HTTPS, Not HTTP
+
+Always use `https://` for remote configuration in production. HTTP URLs are supported but transmit configuration (potentially containing secrets) in plain text.
+
+### 2. Restrict Bucket Permissions
+
+Use least-privilege IAM policies:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::my-bucket/configs/*", "arn:aws:s3:::my-bucket/templates/*"]
+    }
+  ]
+}
+```
+
+### 3. Avoid Secrets in Configuration Files
+
+Use environment variables for sensitive values:
+
+```yaml
+# Good - secrets from environment
+auth:
+  jwt-secret: '${JWT_SECRET}'
+
+connections:
+  postgres:
+    properties:
+      password: '${DB_PASSWORD}'
+```
+
+### 4. Enable Server-Side Encryption
+
+For S3, enable SSE:
+
+```bash
+aws s3 cp flapi.yaml s3://my-bucket/configs/ --sse AES256
+```
+
+### 5. Use VPC Endpoints for Private Access
+
+For AWS, configure VPC endpoints to access S3 without public internet:
+
+```bash
+aws ec2 create-vpc-endpoint \
+  --vpc-id vpc-xxx \
+  --service-name com.amazonaws.us-east-1.s3 \
+  --route-table-ids rtb-xxx
+```
+
+## Troubleshooting
+
+### "Access Denied" Errors
+
+1. Verify credentials are set correctly:
+   ```bash
+   echo $AWS_ACCESS_KEY_ID
+   echo $AWS_REGION
+   ```
+
+2. Test access with AWS CLI:
+   ```bash
+   aws s3 ls s3://my-bucket/configs/
+   ```
+
+3. Check IAM permissions allow `s3:GetObject`
+
+### "File Not Found" Errors
+
+1. Verify the full URL is correct:
+   ```bash
+   curl -I https://example.com/templates/customers.sql
+   ```
+
+2. Check for typos in bucket names or paths
+
+3. Ensure the file exists in the remote location
+
+### Slow Startup Times
+
+Remote configuration loading adds network latency to startup. To minimize impact:
+
+1. Use regional endpoints (same region as your compute)
+2. Keep configuration files small
+3. Consider caching (future feature)
+
+### Template Path Resolution
+
+When using remote `template.path`, relative paths in `template-source` are resolved against it:
+
+```yaml
+# flapi.yaml
+template:
+  path: s3://my-bucket/templates/
+
+# sqls/customers.yaml
+template-source: customers.sql
+# Resolves to: s3://my-bucket/templates/customers.sql
+```
+
+To use a different location, specify a full URL:
+
+```yaml
+template-source: https://other-server.com/templates/customers.sql
+```
+
+## Related Documentation
+
+- [CONFIG_REFERENCE.md](./CONFIG_REFERENCE.md) - Full configuration reference
+- [CLI_REFERENCE.md](./CLI_REFERENCE.md) - Command-line options
+- [features/flapi-10-fs-abstraction.md](./features/flapi-10-fs-abstraction.md) - Technical design document

--- a/docs/features/flapi-10-fs-abstraction.md
+++ b/docs/features/flapi-10-fs-abstraction.md
@@ -1,0 +1,247 @@
+# Designing a Filesystem Abstraction Layer for flAPI
+
+**flAPI can leverage DuckDB's existing VFS to expose cloud storage through Crow's HTTP layer with minimal new code.** The key insight is that DuckDB already provides a mature, production-tested filesystem abstraction with support for S3, Azure, GCS, and HTTP—flAPI needs only thin "glue" to bridge configuration loading and response streaming. This approach minimizes development effort while enabling cloud-native deployments on serverless platforms with read-only filesystems.
+
+## Current architecture reveals natural integration points
+
+flAPI is a C++ API framework built on **DuckDB v1.4.1** and **Crow** that generates REST and MCP endpoints from SQL templates. Currently, all configuration files (YAML endpoints, SQL templates) are loaded from the local filesystem via Docker volume mounts. The architecture consists of three layers that a filesystem abstraction must bridge:
+
+The **configuration layer** uses yaml-cpp to parse endpoint definitions from a `template.path` directory, with support for includes (`{{include from path/to/file.yaml}}`) and environment variable substitution. The **query layer** leverages DuckDB's SQL engine and its extension ecosystem—BigQuery, Postgres, Parquet, Iceberg—already using DuckDB's internal VFS for data access. The **HTTP layer** uses Crow for request handling, response serialization, and static file serving with automatic MIME detection.
+
+DuckDB's `FileSystem` class provides the core abstraction needed:
+
+```cpp
+class FileSystem {
+    virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags);
+    virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
+    virtual void Write(FileHandle &handle, void *data, int64_t nr_bytes, idx_t location);
+    virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
+    virtual vector<OpenFileInfo> GlobFiles(const string &pattern, FileGlobOptions options);
+};
+```
+
+The httpfs and azure extensions already implement this interface for **S3-compatible storage** (AWS, GCS, MinIO, R2), **Azure Blob Storage**, and **HTTP/HTTPS URLs**. Rather than building new filesystem implementations, flAPI should reuse these.
+
+## DuckDB's VFS provides mature cloud storage integration
+
+DuckDB's filesystem architecture is designed for exactly this use case. The `VirtualFileSystem` container routes requests based on URL prefix—`s3://` to S3FileSystem, `az://` to AzureFileSystem, `https://` to HTTPFileSystem—with automatic fallback to LocalFileSystem. Key capabilities include:
+
+**Chunked I/O with configurable buffering**: The Azure extension defaults to **1MB chunks** with parallel transfer threads. S3 uses multi-part uploads for writes. Both support partial reads for range requests, critical for streaming large query results.
+
+**Unified credentials management**: The Secrets Manager pattern handles authentication across providers:
+
+```sql
+CREATE SECRET my_aws (
+    TYPE s3,
+    KEY_ID 'AKIAIOSFODNN7EXAMPLE',
+    SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    REGION 'us-east-1',
+    SCOPE 's3://my-bucket/'
+);
+```
+
+This model maps naturally to flAPI's existing connection configuration, where secrets could be defined once and referenced by template paths.
+
+**Extension-based registration**: Custom filesystems register during extension load via `RegisterSubSystem()`, enabling flAPI to add new storage backends without core changes. The pattern from httpfs shows how to handle URL scheme matching, credential injection, and error propagation.
+
+## Crow requires adaptation for VFS-backed streaming
+
+Crow's file serving is simpler than DuckDB's VFS. Static files use POSIX `stat()` and `std::ifstream` with **16KB chunks** written synchronously. The framework lacks:
+
+- **No virtual filesystem abstraction**: Direct filesystem access only
+- **No HTTP Range request support**: No 206 Partial Content handling
+- **No async file I/O**: Blocking reads in the request thread
+
+However, Crow provides hooks that flAPI can use. The `stream_threshold` setting (default 1MB) automatically streams responses exceeding that size. The `set_static_file_info_unsafe()` method bypasses path sanitization when flAPI controls the path. The middleware system enables authentication and authorization before file access.
+
+The integration pattern requires a custom response handler that reads from DuckDB's VFS and writes to Crow's response:
+
+```cpp
+CROW_ROUTE(app, "/files/<path>")
+([&db_instance](const crow::request& req, crow::response& res, std::string path) {
+    auto& fs = db_instance.GetFileSystem();
+    std::string vfs_path = resolve_to_vfs_url(path); // e.g., "s3://bucket/path"
+    
+    auto handle = fs.OpenFile(vfs_path, FileFlags::READ);
+    int64_t file_size = fs.GetFileSize(*handle);
+    
+    res.set_header("Content-Length", std::to_string(file_size));
+    res.set_header("Accept-Ranges", "bytes");
+    
+    // Stream in 1MB chunks
+    std::vector<char> buffer(1024 * 1024);
+    int64_t offset = 0;
+    while (offset < file_size) {
+        int64_t to_read = std::min((int64_t)buffer.size(), file_size - offset);
+        fs.Read(*handle, buffer.data(), to_read, offset);
+        res.write(std::string(buffer.data(), to_read));
+        offset += to_read;
+    }
+    res.end();
+});
+```
+
+## Serverless constraints shape the configuration strategy
+
+Serverless platforms impose consistent limitations that the abstraction must address:
+
+| Platform | Writable Storage | Temp Limit | Persistent Options |
+|----------|------------------|------------|-------------------|
+| AWS Lambda | `/tmp` only | 512MB-10GB | EFS (requires VPC), S3 |
+| Google Cloud Run | In-memory | Shares container RAM | GCS FUSE, NFS |
+| Azure Functions | `C:\local\Temp` | ~500MB | Azure Files (5TB) |
+| Fly.io | Ephemeral root | 2000 IOPS limit | Volumes (500GB max) |
+
+The critical insight: **configuration files should be read from object storage, not mounted volumes.** This eliminates the need for EFS (which adds cold-start latency) or volume mounts (which complicate deployment).
+
+Environment-based configuration is already idiomatic for serverless:
+
+```yaml
+template:
+  path: '{{env.CONFIG_PATH}}'  # s3://my-bucket/config/ or ./local/
+  environment-whitelist:
+    - '^FLAPI_.*'
+    - '^AWS_.*'
+
+storage:
+  default: '{{env.STORAGE_TYPE}}'  # s3, azure, gcs, local
+  backends:
+    s3:
+      bucket: '{{env.S3_BUCKET}}'
+      region: '{{env.AWS_REGION}}'
+```
+
+For serverless deployment, the startup sequence becomes: load bootstrap config from environment or embedded defaults → initialize DuckDB with httpfs/azure extensions → read full configuration from remote VFS → serve requests.
+
+## Proposed minimal-glue architecture
+
+The filesystem abstraction should be a thin wrapper, not a new implementation:
+
+**Configuration loading adapter**: Modify flAPI's template loader to accept VFS URLs. When `template.path` starts with `s3://`, `gs://`, `az://`, or `https://`, use DuckDB's FileSystem instead of std::filesystem. The existing include resolution (`{{include from path}}`) would work unchanged since DuckDB handles path resolution within each filesystem.
+
+```cpp
+class ConfigLoader {
+    duckdb::FileSystem& vfs_;
+    
+    std::string LoadFile(const std::string& path) {
+        auto handle = vfs_.OpenFile(path, FileFlags::READ);
+        std::string content;
+        content.resize(vfs_.GetFileSize(*handle));
+        vfs_.Read(*handle, content.data(), content.size(), 0);
+        return content;
+    }
+    
+    std::vector<std::string> ListEndpoints(const std::string& directory) {
+        return vfs_.GlobFiles(directory + "/*.yaml", {});
+    }
+};
+```
+
+**HTTP response streaming bridge**: Create a Crow response writer that reads from VFS FileHandle. For large files (exceeding `stream_threshold`), write chunks directly to the socket. For small files, buffer in memory. Add Range request support for resumable downloads:
+
+```cpp
+void StreamVFSFile(crow::response& res, duckdb::FileHandle& handle, 
+                   optional<pair<int64_t, int64_t>> range) {
+    int64_t file_size = handle.GetFileSize();
+    int64_t start = range ? range->first : 0;
+    int64_t end = range ? range->second : file_size - 1;
+    
+    if (range) {
+        res.code = 206;
+        res.set_header("Content-Range", 
+            fmt::format("bytes {}-{}/{}", start, end, file_size));
+    }
+    res.set_header("Content-Length", std::to_string(end - start + 1));
+    // ... stream chunks
+}
+```
+
+**Security layer**: Path validation must happen before VFS access. Implement canonicalization and scope checking:
+
+```cpp
+std::optional<std::string> ValidatePath(const std::string& user_path, 
+                                         const std::string& allowed_prefix) {
+    // Reject traversal attempts
+    if (user_path.find("..") != std::string::npos) return std::nullopt;
+    
+    std::string resolved = resolve_relative_path(allowed_prefix, user_path);
+    if (!resolved.starts_with(allowed_prefix)) return std::nullopt;
+    
+    return resolved;
+}
+```
+
+## Configuration pattern unifies local and cloud deployment
+
+The proposed YAML structure extends flAPI's existing patterns:
+
+```yaml
+project_name: cloud-native-flapi
+
+storage:
+  config_path: 's3://my-bucket/flapi-config/'  # or ./local/
+  cache_path: 's3://my-bucket/flapi-cache/'
+  
+  credentials:
+    s3:
+      type: environment  # reads AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    azure:
+      type: managed_identity
+    gcs:
+      type: service_account
+      key_file: '/secrets/gcs-key.json'
+
+template:
+  path: '{{storage.config_path}}sqls/'
+  
+duckdb:
+  db_path: ':memory:'  # serverless-friendly
+  extensions:
+    - httpfs
+    - azure
+
+connections:
+  data-lake:
+    properties:
+      base_path: 's3://data-lake-bucket/'
+```
+
+For local development, paths remain unchanged (`./sqls/`). For cloud deployment, only `storage.config_path` changes. The same SQL templates work in both environments because they reference connection properties, not absolute paths.
+
+## Implementation requires three focused changes
+
+**Phase 1: VFS-aware configuration loading** (~2 weeks)
+- Modify `TemplateLoader` to detect URL schemes and route to DuckDB FileSystem
+- Add `storage` section to root config schema
+- Implement credential initialization from environment or secrets
+- Ensure `{{include}}` resolution works across VFS boundaries
+
+**Phase 2: HTTP streaming bridge** (~1 week)
+- Create `VFSResponseWriter` that chunks FileHandle reads to Crow responses
+- Add Range request parsing and 206 response generation
+- Integrate with existing authentication middleware
+- Add Content-Type detection for streamed files
+
+**Phase 3: Serverless packaging** (~1 week)
+- Create minimal bootstrap configuration embedded in binary
+- Document Lambda/Cloud Run/Azure Functions deployment patterns
+- Add health check that verifies VFS connectivity
+- Implement graceful degradation when remote storage unavailable
+
+## Security requires defense in depth
+
+Exposing filesystem operations through HTTP demands multiple protection layers:
+
+**Path validation**: All user-provided paths must be validated against allowed prefixes. The existing DuckDB secrets SCOPE feature provides per-path credential isolation. flAPI should add its own allowlist of accessible paths per endpoint.
+
+**Read-only by default**: Serverless environments assume read-only access. flAPI should default to read-only VFS operations, requiring explicit configuration to enable writes (for cache updates).
+
+**Query blacklisting**: The existing `preventSqlInjection` validator should be extended to block filesystem-related SQL injection (e.g., `COPY TO`, `EXPORT DATABASE`).
+
+**Rate limiting**: The current per-endpoint rate limiting applies naturally to file downloads, preventing abuse of cloud egress.
+
+## Conclusion
+
+The filesystem abstraction for flAPI should be minimal glue between DuckDB's mature VFS and Crow's HTTP layer. DuckDB already handles the complex work of cloud storage protocols, authentication, chunked I/O, and error handling. Crow provides the HTTP framework with streaming support. flAPI's contribution is the configuration bridge and security layer—estimated at **500-1000 lines of focused C++ code** rather than a new filesystem implementation.
+
+This approach achieves the stated goal: developer-friendly cloud-native deployment that reuses existing implementations. Local development uses file paths; production uses S3 URLs. The same SQL templates, same endpoint definitions, same authentication—only the storage backend changes.

--- a/examples/cloud-native/flapi-azure.yaml
+++ b/examples/cloud-native/flapi-azure.yaml
@@ -1,0 +1,51 @@
+# flAPI Cloud-Native Configuration: Azure Blob Storage
+#
+# This example shows how to load configuration and templates from Azure.
+#
+# Prerequisites:
+#   export AZURE_STORAGE_ACCOUNT=mystorageaccount
+#   export AZURE_STORAGE_KEY=your-storage-key
+#
+# Or use connection string:
+#   export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;..."
+#
+# Usage:
+#   flapi --config az://my-container/configs/flapi.yaml
+#
+# Or run this local config that references Azure templates:
+#   flapi --config examples/cloud-native/flapi-azure.yaml
+
+project-name: Azure Cloud API
+project-description: API with templates loaded from Azure Blob Storage
+
+# Templates loaded from Azure Blob Storage
+# Note: Change this to your actual Azure container
+template:
+  path: az://flapi-configs/templates/
+  environment-whitelist:
+    - '^AZURE_.*'
+    - '^FLAPI_.*'
+
+# Connection that also uses Azure for data
+connections:
+  azure-parquet:
+    init: |
+      INSTALL azure;
+      LOAD azure;
+    properties:
+      container: flapi-data
+      path: az://flapi-data/customers/
+
+  # Local data for hybrid setup
+  local-data:
+    properties:
+      path: ./data/customers.parquet
+
+# DuckDB settings for serverless (read-only, in-memory)
+duckdb:
+  db_path: ':memory:'
+  access_mode: READ_ONLY
+
+# Server settings
+http-port: 8080
+server-name: localhost

--- a/examples/cloud-native/flapi-https.yaml
+++ b/examples/cloud-native/flapi-https.yaml
@@ -1,0 +1,35 @@
+# flAPI Cloud-Native Configuration: HTTPS
+#
+# This example shows how to load templates from HTTPS URLs.
+# No authentication required for public URLs.
+#
+# Usage:
+#   flapi --config examples/cloud-native/flapi-https.yaml
+#
+# Or load config directly from HTTPS:
+#   flapi --config https://raw.githubusercontent.com/myorg/configs/main/flapi.yaml
+
+project-name: HTTPS Templates API
+project-description: API with templates loaded from HTTPS URLs
+
+# Templates loaded from HTTPS
+# Example uses GitHub raw URLs - replace with your own
+template:
+  path: https://raw.githubusercontent.com/DataZooDE/flapi/main/examples/sqls/
+  environment-whitelist:
+    - '^FLAPI_.*'
+
+# Local data connection
+connections:
+  local-parquet:
+    properties:
+      path: ./data/customers.parquet
+
+# DuckDB settings
+duckdb:
+  db_path: ':memory:'
+  access_mode: READ_ONLY
+
+# Server settings
+http-port: 8080
+server-name: localhost

--- a/examples/cloud-native/flapi-s3.yaml
+++ b/examples/cloud-native/flapi-s3.yaml
@@ -1,0 +1,51 @@
+# flAPI Cloud-Native Configuration: Amazon S3
+#
+# This example shows how to load configuration and templates from S3.
+#
+# Prerequisites:
+#   export AWS_ACCESS_KEY_ID=your-access-key
+#   export AWS_SECRET_ACCESS_KEY=your-secret-key
+#   export AWS_REGION=us-east-1
+#
+# Usage:
+#   flapi --config s3://my-bucket/configs/flapi.yaml
+#
+# Or run this local config that references S3 templates:
+#   flapi --config examples/cloud-native/flapi-s3.yaml
+
+project-name: S3 Cloud API
+project-description: API with templates loaded from Amazon S3
+
+# Templates loaded from S3
+# Note: Change this to your actual S3 bucket
+template:
+  path: s3://flapi-configs/templates/
+  environment-whitelist:
+    - '^AWS_.*'
+    - '^FLAPI_.*'
+
+# Connection that also uses S3 for data
+connections:
+  s3-parquet:
+    init: |
+      INSTALL httpfs;
+      LOAD httpfs;
+      SET s3_region='${AWS_REGION}';
+    properties:
+      # Data files in S3
+      bucket: flapi-data
+      path: s3://flapi-data/customers/
+
+  # Local data for hybrid setup
+  local-data:
+    properties:
+      path: ./data/customers.parquet
+
+# DuckDB settings for serverless (read-only, in-memory)
+duckdb:
+  db_path: ':memory:'
+  access_mode: READ_ONLY
+
+# Server settings
+http-port: 8080
+server-name: localhost

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -1,35 +1,81 @@
 #include "config_loader.hpp"
 #include <crow/logging.h>
-#include <fstream>
 
 namespace flapi {
 
 ConfigLoader::ConfigLoader(const std::filesystem::path& config_file_path)
     : config_file_path_(config_file_path),
-      base_path_(config_file_path_.parent_path()) {
+      config_path_string_(config_file_path.string()),
+      base_path_(config_file_path_.parent_path()),
+      base_path_string_(base_path_.string()),
+      _file_provider(std::make_shared<LocalFileProvider>()),
+      _is_remote(false) {
 
-    // Normalize paths
+    // Normalize paths for local filesystem
     config_file_path_ = std::filesystem::absolute(config_file_path_);
     base_path_ = std::filesystem::absolute(base_path_);
+    config_path_string_ = config_file_path_.string();
+    base_path_string_ = base_path_.string();
 
     CROW_LOG_DEBUG << "ConfigLoader initialized with config file: " << config_file_path_.string();
     CROW_LOG_DEBUG << "Base path for relative path resolution: " << base_path_.string();
 }
 
+ConfigLoader::ConfigLoader(const std::string& config_file_path,
+                           std::shared_ptr<IFileProvider> file_provider)
+    : config_path_string_(config_file_path),
+      _file_provider(std::move(file_provider)),
+      _is_remote(PathSchemeUtils::IsRemotePath(config_file_path)) {
+
+    if (_is_remote) {
+        // For remote paths, extract base path from the URI
+        // e.g., s3://bucket/path/to/flapi.yaml -> s3://bucket/path/to/
+        auto last_slash = config_path_string_.rfind('/');
+        if (last_slash != std::string::npos) {
+            base_path_string_ = config_path_string_.substr(0, last_slash + 1);
+        } else {
+            base_path_string_ = config_path_string_;
+        }
+        // For remote configs, filesystem paths are not meaningful
+        // but we keep them for API compatibility
+        config_file_path_ = std::filesystem::path(config_path_string_);
+        base_path_ = std::filesystem::path(base_path_string_);
+
+        CROW_LOG_DEBUG << "ConfigLoader initialized with remote config: " << config_path_string_;
+        CROW_LOG_DEBUG << "Remote base path: " << base_path_string_;
+    } else {
+        // Local path - normalize using filesystem
+        std::string actual_path = PathSchemeUtils::StripFileScheme(config_file_path);
+        config_file_path_ = std::filesystem::absolute(actual_path);
+        base_path_ = config_file_path_.parent_path();
+        config_path_string_ = config_file_path_.string();
+        base_path_string_ = base_path_.string();
+
+        CROW_LOG_DEBUG << "ConfigLoader initialized with config file: " << config_file_path_.string();
+        CROW_LOG_DEBUG << "Base path for relative path resolution: " << base_path_.string();
+    }
+}
+
 YAML::Node ConfigLoader::loadYamlFile(const std::filesystem::path& file_path) {
     try {
         std::filesystem::path full_path = resolvePath(file_path);
+        std::string path_str = full_path.string();
 
-        if (!std::filesystem::exists(full_path)) {
-            throw std::runtime_error("Configuration file not found: " + full_path.string());
+        // Use file provider for existence check
+        if (!_file_provider->FileExists(path_str)) {
+            throw std::runtime_error("Configuration file not found: " + path_str);
         }
 
-        CROW_LOG_DEBUG << "Loading YAML file: " << full_path.string();
+        CROW_LOG_DEBUG << "Loading YAML file: " << path_str;
 
-        YAML::Node node = YAML::LoadFile(full_path.string());
+        // Read file content using file provider and parse YAML
+        std::string content = _file_provider->ReadFile(path_str);
+        YAML::Node node = YAML::Load(content);
         return node;
     } catch (const YAML::Exception& e) {
         throw std::runtime_error("Failed to parse YAML file '" + file_path.string() + "': " + e.what());
+    } catch (const FileOperationError& e) {
+        throw std::runtime_error("Error loading YAML file '" + file_path.string() + "': " + e.what());
     } catch (const std::exception& e) {
         throw std::runtime_error("Error loading YAML file '" + file_path.string() + "': " + e.what());
     }
@@ -48,12 +94,29 @@ std::filesystem::path ConfigLoader::resolvePath(const std::filesystem::path& rel
         return base_path_;
     }
 
+    std::string path_str = relative_path.string();
+
+    // If path is a remote URI, return it as-is
+    if (PathSchemeUtils::IsRemotePath(path_str)) {
+        return relative_path;
+    }
+
     // If path is already absolute, return it as-is
     if (relative_path.is_absolute()) {
         return relative_path;
     }
 
-    // Otherwise, resolve relative to base path
+    // For remote base paths, concatenate strings
+    if (_is_remote) {
+        std::string resolved = base_path_string_;
+        if (!resolved.empty() && resolved.back() != '/') {
+            resolved += '/';
+        }
+        resolved += path_str;
+        return std::filesystem::path(resolved);
+    }
+
+    // Otherwise, resolve relative to base path (local filesystem)
     std::filesystem::path resolved = base_path_ / relative_path;
 
     // Normalize the path (resolve .. and .)
@@ -68,11 +131,28 @@ std::filesystem::path ConfigLoader::resolvePath(const std::filesystem::path& rel
 }
 
 bool ConfigLoader::fileExists(const std::filesystem::path& file_path) const {
-    return std::filesystem::exists(file_path) && std::filesystem::is_regular_file(file_path);
+    return _file_provider->FileExists(file_path.string());
 }
 
 bool ConfigLoader::directoryExists(const std::filesystem::path& dir_path) const {
+    // For remote paths, we can't easily check if a directory exists
+    // Most cloud storage systems don't have true directories
+    if (_is_remote || PathSchemeUtils::IsRemotePath(dir_path.string())) {
+        // For remote storage, assume directory exists if we can list files in it
+        // This is a best-effort check
+        return true;
+    }
     return std::filesystem::exists(dir_path) && std::filesystem::is_directory(dir_path);
+}
+
+bool ConfigLoader::isRemoteConfig() const {
+    return _is_remote;
+}
+
+std::string ConfigLoader::readFile(const std::string& file_path) const {
+    // Resolve the path first
+    std::filesystem::path resolved = resolvePath(std::filesystem::path(file_path));
+    return _file_provider->ReadFile(resolved.string());
 }
 
 } // namespace flapi

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -1035,6 +1035,7 @@ int ConfigManager::getHttpPort() const { return http_port; }
 void ConfigManager::setHttpPort(int port) { http_port = port; }
 std::string ConfigManager::getTemplatePath() const { return template_config.path; }
 std::filesystem::path ConfigManager::getFullTemplatePath() const { return std::filesystem::path(base_path) / template_config.path; }
+std::shared_ptr<IFileProvider> ConfigManager::getFileProvider() const { return config_loader->getFileProvider(); }
 std::string ConfigManager::getCacheSchema() const { return cache_schema; }
 const std::unordered_map<std::string, ConnectionConfig>& ConfigManager::getConnections() const { return connections; }
 const RateLimitConfig& ConfigManager::getRateLimitConfig() const { return rate_limit_config; }

--- a/src/include/config_loader.hpp
+++ b/src/include/config_loader.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <yaml-cpp/yaml.h>
+#include "vfs_adapter.hpp"
 
 namespace flapi {
 
@@ -10,15 +12,30 @@ namespace flapi {
  * Responsible for loading and parsing YAML configuration files.
  * Handles file I/O, path resolution, and basic YAML parsing operations.
  * Does NOT interpret or validate the configuration - that's done elsewhere.
+ *
+ * Supports loading configurations from:
+ * - Local filesystem (default)
+ * - Remote storage via VFS (S3, GCS, Azure, HTTP/HTTPS) when appropriate provider is set
  */
 class ConfigLoader {
 public:
     /**
      * Create a ConfigLoader for a specific configuration file.
+     * Uses LocalFileProvider by default for backward compatibility.
      *
      * @param config_file_path Path to the main flapi.yaml configuration file
      */
     explicit ConfigLoader(const std::filesystem::path& config_file_path);
+
+    /**
+     * Create a ConfigLoader with a custom file provider.
+     * Use this constructor when loading configs from remote storage.
+     *
+     * @param config_file_path Path or URI to the main flapi.yaml configuration file
+     * @param file_provider Custom file provider for file operations
+     */
+    ConfigLoader(const std::string& config_file_path,
+                 std::shared_ptr<IFileProvider> file_provider);
 
     /**
      * Load and parse a YAML file from disk.
@@ -77,9 +94,44 @@ public:
      */
     std::filesystem::path getConfigFilePath() const { return config_file_path_; }
 
+    /**
+     * Get the main configuration file path as string.
+     * Useful for remote paths that aren't valid filesystem paths.
+     *
+     * @return Path string to the main configuration file
+     */
+    std::string getConfigFilePathString() const { return config_path_string_; }
+
+    /**
+     * Check if the configuration is loaded from a remote source.
+     *
+     * @return true if config path uses a remote scheme (s3://, https://, etc.)
+     */
+    bool isRemoteConfig() const;
+
+    /**
+     * Read raw file contents using the configured file provider.
+     *
+     * @param file_path Path to the file (can be relative or absolute)
+     * @return File contents as string
+     * @throws std::runtime_error if file cannot be read
+     */
+    std::string readFile(const std::string& file_path) const;
+
+    /**
+     * Get the file provider being used.
+     *
+     * @return Shared pointer to the file provider
+     */
+    std::shared_ptr<IFileProvider> getFileProvider() const { return _file_provider; }
+
 private:
-    std::filesystem::path config_file_path_;
-    std::filesystem::path base_path_;
+    std::filesystem::path config_file_path_;  // For local paths (backward compat)
+    std::string config_path_string_;          // Original path string (supports remote)
+    std::filesystem::path base_path_;         // Base path for relative resolution
+    std::string base_path_string_;            // Base path as string (supports remote)
+    std::shared_ptr<IFileProvider> _file_provider;
+    bool _is_remote;
 };
 
 } // namespace flapi

--- a/src/include/config_manager.hpp
+++ b/src/include/config_manager.hpp
@@ -448,6 +448,7 @@ class ConfigLoader;
 class EndpointRepository;
 class ConfigValidator;
 class ConfigSerializer;
+class IFileProvider;
 
 class ConfigManager {
     // Allow EndpointConfigParser to access protected parsing methods
@@ -493,6 +494,9 @@ public:
     std::string getDuckDBPath() const;
     ExtendedYamlParser& getYamlParser() { return yaml_parser; }
     std::filesystem::path getFullTemplatePath() const;
+
+    // Get the file provider for VFS operations (local or remote file access)
+    std::shared_ptr<IFileProvider> getFileProvider() const;
 
     const GlobalHeartbeatConfig& getGlobalHeartbeatConfig() const { return global_heartbeat_config; }
     const DuckLakeConfig& getDuckLakeConfig() const { return ducklake_config; }

--- a/src/include/path_validator.hpp
+++ b/src/include/path_validator.hpp
@@ -34,6 +34,12 @@ public:
 
         // Whether to allow relative paths
         bool allow_relative_paths = true;
+
+        // Use filesystem-based canonicalization (resolves symlinks).
+        // When true, uses std::filesystem::canonical/weakly_canonical
+        // to resolve symlinks and verify the real path is within allowed prefixes.
+        // This provides stronger security but requires the path to exist.
+        bool resolve_symlinks = false;
     };
 
     /**
@@ -127,12 +133,21 @@ public:
     static bool ContainsTraversal(const std::string& path);
 
     /**
-     * URL-decode a string (handles %2e%2e for .. etc).
+     * URL-decode a string iteratively (handles %252e%252e for double-encoded .. etc).
+     * Decodes up to 3 times to catch multi-encoded traversal attempts.
      *
      * @param encoded The URL-encoded string
-     * @return Decoded string
+     * @return Fully decoded string
      */
     static std::string UrlDecode(const std::string& encoded);
+
+    /**
+     * URL-decode a string once (single pass).
+     *
+     * @param encoded The URL-encoded string
+     * @return Decoded string (one level)
+     */
+    static std::string UrlDecodeSingle(const std::string& encoded);
 
     /**
      * Extract scheme from a path/URI.

--- a/src/include/path_validator.hpp
+++ b/src/include/path_validator.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+#include <set>
+
+namespace flapi {
+
+/**
+ * Security-focused path validation to prevent traversal attacks and
+ * enforce access controls on file paths.
+ *
+ * This class provides:
+ * - Path traversal attack prevention (blocking '..' sequences)
+ * - Prefix-based access control (paths must be under allowed prefixes)
+ * - URL scheme whitelisting (only configured schemes are allowed)
+ * - Path canonicalization for consistent validation
+ */
+class PathValidator {
+public:
+    /**
+     * Configuration for path validation.
+     */
+    struct Config {
+        // Allowed URL schemes (default: file, https)
+        std::set<std::string> allowed_schemes = {"file", "https"};
+
+        // Whether to allow local file paths (paths without scheme)
+        bool allow_local_paths = true;
+
+        // Allowed path prefixes for local paths (empty = all allowed)
+        std::vector<std::string> allowed_prefixes;
+
+        // Whether to allow relative paths
+        bool allow_relative_paths = true;
+    };
+
+    /**
+     * Result of path validation.
+     */
+    struct ValidationResult {
+        bool valid = false;
+        std::string canonical_path;
+        std::string error_message;
+
+        static ValidationResult Success(const std::string& path) {
+            return {true, path, ""};
+        }
+
+        static ValidationResult Failure(const std::string& error) {
+            return {false, "", error};
+        }
+    };
+
+    /**
+     * Create a PathValidator with default configuration.
+     */
+    PathValidator();
+
+    /**
+     * Create a PathValidator with custom configuration.
+     */
+    explicit PathValidator(const Config& config);
+
+    /**
+     * Validate a user-provided path.
+     *
+     * @param user_path The path to validate (can be absolute, relative, or URI)
+     * @param base_path Optional base path for resolving relative paths
+     * @return ValidationResult with canonical path if valid, error message if not
+     */
+    ValidationResult ValidatePath(const std::string& user_path,
+                                  const std::string& base_path = "") const;
+
+    /**
+     * Check if a URL scheme is allowed by configuration.
+     *
+     * @param scheme The scheme to check (e.g., "s3", "https", "file")
+     * @return true if the scheme is allowed
+     */
+    bool IsSchemeAllowed(const std::string& scheme) const;
+
+    /**
+     * Canonicalize a path by resolving relative components.
+     * Does NOT check filesystem - purely string-based canonicalization.
+     *
+     * @param base The base path
+     * @param relative The relative path to resolve
+     * @return Canonicalized path, or empty string if traversal detected
+     */
+    std::string Canonicalize(const std::string& base,
+                             const std::string& relative) const;
+
+    /**
+     * Check if a path is within an allowed prefix.
+     *
+     * @param path The canonical path to check
+     * @return true if path starts with an allowed prefix (or no prefixes configured)
+     */
+    bool IsPathAllowed(const std::string& path) const;
+
+    /**
+     * Add an allowed scheme to the configuration.
+     */
+    void AddAllowedScheme(const std::string& scheme);
+
+    /**
+     * Add an allowed path prefix.
+     */
+    void AddAllowedPrefix(const std::string& prefix);
+
+    /**
+     * Get current configuration.
+     */
+    const Config& GetConfig() const { return _config; }
+
+    // Static utility methods
+
+    /**
+     * Check if a path contains path traversal sequences.
+     * Checks for '..' after URL decoding.
+     *
+     * @param path The path to check
+     * @return true if path contains traversal sequences
+     */
+    static bool ContainsTraversal(const std::string& path);
+
+    /**
+     * URL-decode a string (handles %2e%2e for .. etc).
+     *
+     * @param encoded The URL-encoded string
+     * @return Decoded string
+     */
+    static std::string UrlDecode(const std::string& encoded);
+
+    /**
+     * Extract scheme from a path/URI.
+     *
+     * @param path The path or URI
+     * @return Scheme (e.g., "s3", "https") or empty if no scheme
+     */
+    static std::string ExtractScheme(const std::string& path);
+
+    /**
+     * Check if a path is a remote URI (has a network scheme).
+     *
+     * @param path The path to check
+     * @return true if path starts with s3://, gs://, https://, etc.
+     */
+    static bool IsRemotePath(const std::string& path);
+
+private:
+    Config _config;
+
+    // Validate a local filesystem path
+    ValidationResult ValidateLocalPath(const std::string& path,
+                                       const std::string& base_path) const;
+
+    // Validate a remote URI
+    ValidationResult ValidateRemotePath(const std::string& path) const;
+
+    // Normalize path separators to forward slashes
+    static std::string NormalizeSeparators(const std::string& path);
+};
+
+} // namespace flapi

--- a/src/include/vfs_adapter.hpp
+++ b/src/include/vfs_adapter.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <stdexcept>
+
+namespace flapi {
+
+/**
+ * Exception thrown when a file operation fails.
+ */
+class FileOperationError : public std::runtime_error {
+public:
+    explicit FileOperationError(const std::string& message)
+        : std::runtime_error(message) {}
+};
+
+/**
+ * Abstract interface for file operations.
+ * Provides a unified API for reading files from local filesystem or remote storage.
+ *
+ * Implementations:
+ * - LocalFileProvider: Standard filesystem operations (std::filesystem)
+ * - DuckDBVFSProvider: DuckDB's VFS for S3, GCS, Azure, HTTP (future)
+ */
+class IFileProvider {
+public:
+    virtual ~IFileProvider() = default;
+
+    /**
+     * Read the entire contents of a file.
+     *
+     * @param path File path (local path or URI like s3://bucket/key)
+     * @return File contents as string
+     * @throws FileOperationError if file cannot be read
+     */
+    virtual std::string ReadFile(const std::string& path) = 0;
+
+    /**
+     * Check if a file exists.
+     *
+     * @param path File path to check
+     * @return true if file exists and is readable
+     */
+    virtual bool FileExists(const std::string& path) = 0;
+
+    /**
+     * List files in a directory matching a pattern.
+     *
+     * @param directory Directory path to search
+     * @param pattern Glob pattern (e.g., "*.yaml", "*.sql")
+     * @return Vector of matching file paths
+     * @throws FileOperationError if directory cannot be accessed
+     */
+    virtual std::vector<std::string> ListFiles(const std::string& directory,
+                                                const std::string& pattern = "*") = 0;
+
+    /**
+     * Check if a path refers to a remote resource (S3, GCS, Azure, HTTP).
+     *
+     * @param path Path to check
+     * @return true if path uses a remote URI scheme
+     */
+    virtual bool IsRemotePath(const std::string& path) const = 0;
+
+    /**
+     * Get the provider name for debugging/logging.
+     *
+     * @return Provider name (e.g., "local", "duckdb-vfs")
+     */
+    virtual std::string GetProviderName() const = 0;
+};
+
+/**
+ * Utility functions for path scheme detection.
+ */
+class PathSchemeUtils {
+public:
+    /**
+     * Supported URI schemes for remote storage.
+     */
+    static constexpr const char* SCHEME_S3 = "s3://";
+    static constexpr const char* SCHEME_GCS = "gs://";
+    static constexpr const char* SCHEME_AZURE = "az://";
+    static constexpr const char* SCHEME_AZURE_BLOB = "azure://";
+    static constexpr const char* SCHEME_HTTP = "http://";
+    static constexpr const char* SCHEME_HTTPS = "https://";
+    static constexpr const char* SCHEME_FILE = "file://";
+
+    /**
+     * Check if a path is a remote URI.
+     *
+     * @param path Path to check
+     * @return true if path starts with a remote scheme (s3://, gs://, az://, http://, https://)
+     */
+    static bool IsRemotePath(const std::string& path);
+
+    /**
+     * Check if a path uses the S3 scheme.
+     */
+    static bool IsS3Path(const std::string& path);
+
+    /**
+     * Check if a path uses the GCS scheme.
+     */
+    static bool IsGCSPath(const std::string& path);
+
+    /**
+     * Check if a path uses the Azure scheme.
+     */
+    static bool IsAzurePath(const std::string& path);
+
+    /**
+     * Check if a path uses HTTP/HTTPS scheme.
+     */
+    static bool IsHttpPath(const std::string& path);
+
+    /**
+     * Check if a path uses the file:// scheme.
+     */
+    static bool IsFilePath(const std::string& path);
+
+    /**
+     * Extract the scheme from a path.
+     *
+     * @param path Path to extract scheme from
+     * @return Scheme string (e.g., "s3://", "https://") or empty if local path
+     */
+    static std::string GetScheme(const std::string& path);
+
+    /**
+     * Remove the file:// scheme prefix if present.
+     *
+     * @param path Path potentially with file:// prefix
+     * @return Path without file:// prefix
+     */
+    static std::string StripFileScheme(const std::string& path);
+};
+
+/**
+ * File provider implementation using the local filesystem.
+ * Uses std::filesystem for all operations.
+ */
+class LocalFileProvider : public IFileProvider {
+public:
+    LocalFileProvider() = default;
+    ~LocalFileProvider() override = default;
+
+    std::string ReadFile(const std::string& path) override;
+    bool FileExists(const std::string& path) override;
+    std::vector<std::string> ListFiles(const std::string& directory,
+                                        const std::string& pattern = "*") override;
+    bool IsRemotePath(const std::string& path) const override;
+    std::string GetProviderName() const override { return "local"; }
+};
+
+/**
+ * Factory for creating file providers based on path scheme.
+ */
+class FileProviderFactory {
+public:
+    /**
+     * Create an appropriate file provider for the given path.
+     * Currently returns LocalFileProvider for all local paths.
+     * Future: Will return DuckDBVFSProvider for remote paths.
+     *
+     * @param path Path to create provider for (used to detect scheme)
+     * @return Shared pointer to appropriate file provider
+     */
+    static std::shared_ptr<IFileProvider> CreateProvider(const std::string& path);
+
+    /**
+     * Create a local file provider.
+     */
+    static std::shared_ptr<IFileProvider> CreateLocalProvider();
+};
+
+} // namespace flapi

--- a/src/path_validator.cpp
+++ b/src/path_validator.cpp
@@ -1,0 +1,298 @@
+#include "path_validator.hpp"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace flapi {
+
+PathValidator::PathValidator() : _config() {}
+
+PathValidator::PathValidator(const Config& config) : _config(config) {}
+
+PathValidator::ValidationResult PathValidator::ValidatePath(
+    const std::string& user_path,
+    const std::string& base_path) const {
+
+    if (user_path.empty()) {
+        return ValidationResult::Failure("Path cannot be empty");
+    }
+
+    // URL decode the path first to catch encoded traversal attempts
+    std::string decoded_path = UrlDecode(user_path);
+
+    // Check for traversal sequences after decoding
+    if (ContainsTraversal(decoded_path)) {
+        return ValidationResult::Failure("Path traversal not allowed");
+    }
+
+    // Check if it's a remote path
+    if (IsRemotePath(decoded_path)) {
+        return ValidateRemotePath(decoded_path);
+    }
+
+    // Handle local paths
+    return ValidateLocalPath(decoded_path, base_path);
+}
+
+PathValidator::ValidationResult PathValidator::ValidateLocalPath(
+    const std::string& path,
+    const std::string& base_path) const {
+
+    if (!_config.allow_local_paths) {
+        return ValidationResult::Failure("Local paths not allowed");
+    }
+
+    std::string canonical;
+
+    // Check if path is absolute
+    bool is_absolute = !path.empty() && (path[0] == '/' ||
+                       (path.length() > 1 && path[1] == ':'));  // Windows
+
+    if (is_absolute) {
+        canonical = NormalizeSeparators(path);
+    } else {
+        // Relative path - need a base
+        if (!_config.allow_relative_paths) {
+            return ValidationResult::Failure("Relative paths not allowed");
+        }
+
+        if (base_path.empty()) {
+            return ValidationResult::Failure("Relative path requires a base path");
+        }
+
+        canonical = Canonicalize(base_path, path);
+        if (canonical.empty()) {
+            return ValidationResult::Failure("Path traversal not allowed");
+        }
+    }
+
+    // Check against allowed prefixes
+    if (!IsPathAllowed(canonical)) {
+        return ValidationResult::Failure("Path not within allowed directory");
+    }
+
+    return ValidationResult::Success(canonical);
+}
+
+PathValidator::ValidationResult PathValidator::ValidateRemotePath(
+    const std::string& path) const {
+
+    std::string scheme = ExtractScheme(path);
+
+    if (scheme.empty()) {
+        return ValidationResult::Failure("Invalid URI format");
+    }
+
+    if (!IsSchemeAllowed(scheme)) {
+        return ValidationResult::Failure("URL scheme not allowed: " + scheme);
+    }
+
+    // For remote paths, normalize separators but don't do filesystem-style
+    // canonicalization (remote paths don't support '..' resolution the same way)
+    std::string normalized = NormalizeSeparators(path);
+
+    return ValidationResult::Success(normalized);
+}
+
+bool PathValidator::IsSchemeAllowed(const std::string& scheme) const {
+    return _config.allowed_schemes.find(scheme) != _config.allowed_schemes.end();
+}
+
+std::string PathValidator::Canonicalize(const std::string& base,
+                                        const std::string& relative) const {
+    if (relative.empty()) {
+        return NormalizeSeparators(base);
+    }
+
+    // Check for traversal in relative path
+    if (ContainsTraversal(relative)) {
+        return "";  // Traversal detected
+    }
+
+    std::string normalized_base = NormalizeSeparators(base);
+    std::string normalized_rel = NormalizeSeparators(relative);
+
+    // Ensure base ends with /
+    if (!normalized_base.empty() && normalized_base.back() != '/') {
+        normalized_base += '/';
+    }
+
+    // Handle ./ prefix in relative path
+    if (normalized_rel.length() >= 2 &&
+        normalized_rel[0] == '.' && normalized_rel[1] == '/') {
+        normalized_rel = normalized_rel.substr(2);
+    }
+
+    // Simple concatenation (traversal already checked)
+    std::string result = normalized_base + normalized_rel;
+
+    // Clean up any // sequences
+    std::string cleaned;
+    bool last_was_slash = false;
+    for (char c : result) {
+        if (c == '/') {
+            if (!last_was_slash) {
+                cleaned += c;
+            }
+            last_was_slash = true;
+        } else {
+            cleaned += c;
+            last_was_slash = false;
+        }
+    }
+
+    return cleaned;
+}
+
+bool PathValidator::IsPathAllowed(const std::string& path) const {
+    // If no prefixes configured, allow all paths
+    if (_config.allowed_prefixes.empty()) {
+        return true;
+    }
+
+    std::string normalized_path = NormalizeSeparators(path);
+
+    for (const auto& prefix : _config.allowed_prefixes) {
+        std::string normalized_prefix = NormalizeSeparators(prefix);
+
+        // Ensure prefix ends with / for directory matching
+        if (!normalized_prefix.empty() && normalized_prefix.back() != '/') {
+            normalized_prefix += '/';
+        }
+
+        // Check if path starts with prefix, or path equals prefix without trailing /
+        if (normalized_path.find(normalized_prefix) == 0) {
+            return true;
+        }
+
+        // Also allow exact match without trailing slash
+        std::string prefix_no_slash = normalized_prefix;
+        if (!prefix_no_slash.empty() && prefix_no_slash.back() == '/') {
+            prefix_no_slash.pop_back();
+        }
+        if (normalized_path == prefix_no_slash) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void PathValidator::AddAllowedScheme(const std::string& scheme) {
+    _config.allowed_schemes.insert(scheme);
+}
+
+void PathValidator::AddAllowedPrefix(const std::string& prefix) {
+    _config.allowed_prefixes.push_back(prefix);
+}
+
+bool PathValidator::ContainsTraversal(const std::string& path) {
+    // Check for '..' sequence which could be used for traversal
+    // This catches: .., /../, \..\, etc.
+
+    std::string normalized = NormalizeSeparators(path);
+
+    // Check for standalone '..'
+    if (normalized == "..") {
+        return true;
+    }
+
+    // Check for '../' at start
+    if (normalized.length() >= 3 && normalized.substr(0, 3) == "../") {
+        return true;
+    }
+
+    // Check for '/..' followed by '/' or end of string anywhere in the path
+    // This avoids false positives like /...file.txt (three dots)
+    size_t pos = 0;
+    while ((pos = normalized.find("/..", pos)) != std::string::npos) {
+        // Check what follows the '/..': must be '/' or end of string
+        size_t after_pos = pos + 3;
+        if (after_pos >= normalized.length() || normalized[after_pos] == '/') {
+            return true;
+        }
+        pos++;  // Move past this occurrence to check for more
+    }
+
+    return false;
+}
+
+std::string PathValidator::UrlDecode(const std::string& encoded) {
+    std::string result;
+    result.reserve(encoded.length());
+
+    for (size_t i = 0; i < encoded.length(); ++i) {
+        if (encoded[i] == '%' && i + 2 < encoded.length()) {
+            // Check if next two chars are hex digits
+            char h1 = encoded[i + 1];
+            char h2 = encoded[i + 2];
+
+            if (std::isxdigit(static_cast<unsigned char>(h1)) &&
+                std::isxdigit(static_cast<unsigned char>(h2))) {
+                // Convert hex to char
+                int value = 0;
+                std::istringstream iss(encoded.substr(i + 1, 2));
+                iss >> std::hex >> value;
+                result += static_cast<char>(value);
+                i += 2;
+                continue;
+            }
+        } else if (encoded[i] == '+') {
+            // + is sometimes used for space in query strings
+            result += ' ';
+            continue;
+        }
+        result += encoded[i];
+    }
+
+    return result;
+}
+
+std::string PathValidator::ExtractScheme(const std::string& path) {
+    // Look for "scheme://"
+    size_t pos = path.find("://");
+    if (pos == std::string::npos || pos == 0) {
+        return "";
+    }
+
+    std::string scheme = path.substr(0, pos);
+
+    // Validate scheme contains only valid characters (letters, digits, +, -, .)
+    for (char c : scheme) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) &&
+            c != '+' && c != '-' && c != '.') {
+            return "";
+        }
+    }
+
+    // Convert to lowercase for comparison
+    std::transform(scheme.begin(), scheme.end(), scheme.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    return scheme;
+}
+
+bool PathValidator::IsRemotePath(const std::string& path) {
+    std::string scheme = ExtractScheme(path);
+    if (scheme.empty()) {
+        return false;
+    }
+
+    // These schemes are considered "remote" (network-based)
+    static const std::set<std::string> remote_schemes = {
+        "s3", "gs", "az", "abfs", "abfss",  // Cloud storage
+        "http", "https",                      // HTTP
+        "ftp", "ftps", "sftp"                 // FTP
+    };
+
+    return remote_schemes.find(scheme) != remote_schemes.end();
+}
+
+std::string PathValidator::NormalizeSeparators(const std::string& path) {
+    std::string result = path;
+    // Replace backslashes with forward slashes (Windows compatibility)
+    std::replace(result.begin(), result.end(), '\\', '/');
+    return result;
+}
+
+} // namespace flapi

--- a/src/vfs_adapter.cpp
+++ b/src/vfs_adapter.cpp
@@ -1,0 +1,203 @@
+#include "vfs_adapter.hpp"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <regex>
+
+namespace flapi {
+
+// ============================================================================
+// PathSchemeUtils Implementation
+// ============================================================================
+
+bool PathSchemeUtils::IsRemotePath(const std::string& path) {
+    return IsS3Path(path) || IsGCSPath(path) || IsAzurePath(path) || IsHttpPath(path);
+}
+
+bool PathSchemeUtils::IsS3Path(const std::string& path) {
+    return path.rfind(SCHEME_S3, 0) == 0;
+}
+
+bool PathSchemeUtils::IsGCSPath(const std::string& path) {
+    return path.rfind(SCHEME_GCS, 0) == 0;
+}
+
+bool PathSchemeUtils::IsAzurePath(const std::string& path) {
+    return path.rfind(SCHEME_AZURE, 0) == 0 || path.rfind(SCHEME_AZURE_BLOB, 0) == 0;
+}
+
+bool PathSchemeUtils::IsHttpPath(const std::string& path) {
+    return path.rfind(SCHEME_HTTP, 0) == 0 || path.rfind(SCHEME_HTTPS, 0) == 0;
+}
+
+bool PathSchemeUtils::IsFilePath(const std::string& path) {
+    return path.rfind(SCHEME_FILE, 0) == 0;
+}
+
+std::string PathSchemeUtils::GetScheme(const std::string& path) {
+    if (IsS3Path(path)) {
+        return SCHEME_S3;
+    }
+    if (IsGCSPath(path)) {
+        return SCHEME_GCS;
+    }
+    if (path.rfind(SCHEME_AZURE_BLOB, 0) == 0) {
+        return SCHEME_AZURE_BLOB;
+    }
+    if (path.rfind(SCHEME_AZURE, 0) == 0) {
+        return SCHEME_AZURE;
+    }
+    if (path.rfind(SCHEME_HTTPS, 0) == 0) {
+        return SCHEME_HTTPS;
+    }
+    if (path.rfind(SCHEME_HTTP, 0) == 0) {
+        return SCHEME_HTTP;
+    }
+    if (IsFilePath(path)) {
+        return SCHEME_FILE;
+    }
+    return "";
+}
+
+std::string PathSchemeUtils::StripFileScheme(const std::string& path) {
+    if (IsFilePath(path)) {
+        return path.substr(std::string(SCHEME_FILE).length());
+    }
+    return path;
+}
+
+// ============================================================================
+// LocalFileProvider Implementation
+// ============================================================================
+
+std::string LocalFileProvider::ReadFile(const std::string& path) {
+    // Handle file:// scheme
+    std::string actual_path = PathSchemeUtils::StripFileScheme(path);
+
+    // Check if file exists first
+    if (!FileExists(actual_path)) {
+        throw FileOperationError("File not found: " + path);
+    }
+
+    std::ifstream file(actual_path, std::ios::in | std::ios::binary);
+    if (!file) {
+        throw FileOperationError("Failed to open file: " + path);
+    }
+
+    std::ostringstream contents;
+    contents << file.rdbuf();
+
+    if (file.bad()) {
+        throw FileOperationError("Error reading file: " + path);
+    }
+
+    return contents.str();
+}
+
+bool LocalFileProvider::FileExists(const std::string& path) {
+    // Handle file:// scheme
+    std::string actual_path = PathSchemeUtils::StripFileScheme(path);
+
+    // Don't check remote paths
+    if (PathSchemeUtils::IsRemotePath(actual_path)) {
+        return false;
+    }
+
+    try {
+        return std::filesystem::exists(actual_path) &&
+               std::filesystem::is_regular_file(actual_path);
+    } catch (const std::filesystem::filesystem_error&) {
+        return false;
+    }
+}
+
+std::vector<std::string> LocalFileProvider::ListFiles(const std::string& directory,
+                                                       const std::string& pattern) {
+    // Handle file:// scheme
+    std::string actual_dir = PathSchemeUtils::StripFileScheme(directory);
+
+    std::vector<std::string> result;
+
+    if (!std::filesystem::exists(actual_dir) ||
+        !std::filesystem::is_directory(actual_dir)) {
+        throw FileOperationError("Directory not found: " + directory);
+    }
+
+    // Convert glob pattern to regex
+    // Simple conversion: * -> .*, ? -> ., escape other special chars
+    std::string regex_pattern;
+    for (char c : pattern) {
+        switch (c) {
+            case '*':
+                regex_pattern += ".*";
+                break;
+            case '?':
+                regex_pattern += ".";
+                break;
+            case '.':
+            case '+':
+            case '^':
+            case '$':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '|':
+            case '\\':
+                regex_pattern += '\\';
+                regex_pattern += c;
+                break;
+            default:
+                regex_pattern += c;
+                break;
+        }
+    }
+
+    std::regex file_regex(regex_pattern, std::regex::icase);
+
+    try {
+        for (const auto& entry : std::filesystem::directory_iterator(actual_dir)) {
+            if (entry.is_regular_file()) {
+                std::string filename = entry.path().filename().string();
+                if (std::regex_match(filename, file_regex)) {
+                    result.push_back(entry.path().string());
+                }
+            }
+        }
+    } catch (const std::filesystem::filesystem_error& e) {
+        throw FileOperationError("Failed to list directory: " + directory + " - " + e.what());
+    }
+
+    // Sort for consistent ordering
+    std::sort(result.begin(), result.end());
+
+    return result;
+}
+
+bool LocalFileProvider::IsRemotePath(const std::string& path) const {
+    return PathSchemeUtils::IsRemotePath(path);
+}
+
+// ============================================================================
+// FileProviderFactory Implementation
+// ============================================================================
+
+std::shared_ptr<IFileProvider> FileProviderFactory::CreateProvider(const std::string& path) {
+    if (PathSchemeUtils::IsRemotePath(path)) {
+        // Future: Return DuckDBVFSProvider for remote paths
+        // For now, throw an error since remote paths aren't supported yet
+        throw FileOperationError(
+            "Remote paths are not yet supported: " + path +
+            ". DuckDBVFSProvider will be implemented in a future task.");
+    }
+    return CreateLocalProvider();
+}
+
+std::shared_ptr<IFileProvider> FileProviderFactory::CreateLocalProvider() {
+    return std::make_shared<LocalFileProvider>();
+}
+
+} // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(flapi_tests
     test_arrow_compression.cpp
     test_arrow_configuration.cpp
     test_arrow_metrics.cpp
+    test_vfs_adapter.cpp
 )
 
 target_include_directories(flapi_tests PRIVATE 

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(flapi_tests
     test_arrow_configuration.cpp
     test_arrow_metrics.cpp
     test_vfs_adapter.cpp
+    test_path_validator.cpp
 )
 
 target_include_directories(flapi_tests PRIVATE 

--- a/test/cpp/config_manager_test.cpp
+++ b/test/cpp/config_manager_test.cpp
@@ -195,7 +195,11 @@ cache:
         const auto& endpoint = endpoints[0];
 
         REQUIRE(endpoint.urlPath == "/test");
-        REQUIRE(endpoint.templateSource == "/tmp/test.sql");
+        // Template source is resolved relative to endpoint config file's directory
+        // Note: templateSource is not canonicalized, so we compare without canonical()
+        std::filesystem::path endpoint_dir = std::filesystem::path(endpoint_file).parent_path();
+        std::filesystem::path expected_template = endpoint_dir / "test.sql";
+        REQUIRE(endpoint.templateSource == expected_template.string());
         REQUIRE(endpoint.connection == std::vector<std::string>{"default"});
 
         REQUIRE(endpoint.request_fields.size() == 1);

--- a/test/cpp/test_config_loader.cpp
+++ b/test/cpp/test_config_loader.cpp
@@ -120,7 +120,8 @@ TEST_CASE("ConfigLoader path resolution", "[config][loader]") {
         std::ofstream(test_file) << "test";
 
         std::filesystem::path resolved = loader.resolvePath("test.yaml");
-        REQUIRE(resolved == test_file);
+        // Use canonical to handle macOS /var -> /private/var symlinks
+        REQUIRE(resolved == std::filesystem::canonical(test_file));
 
         std::filesystem::remove(test_file);
     }
@@ -136,7 +137,8 @@ TEST_CASE("ConfigLoader path resolution", "[config][loader]") {
         std::ofstream(test_file) << "test";
 
         std::filesystem::path resolved = loader.resolvePath("subdir/test.yaml");
-        REQUIRE(resolved == test_file);
+        // Use canonical to handle macOS /var -> /private/var symlinks
+        REQUIRE(resolved == std::filesystem::canonical(test_file));
 
         std::filesystem::remove(test_file);
         std::filesystem::remove(test_dir);
@@ -158,7 +160,8 @@ TEST_CASE("ConfigLoader path resolution", "[config][loader]") {
         std::ofstream(test_file) << "test";
 
         std::filesystem::path resolved = loader.resolvePath("./test.yaml");
-        REQUIRE(resolved == test_file);
+        // Use canonical to handle macOS /var -> /private/var symlinks
+        REQUIRE(resolved == std::filesystem::canonical(test_file));
 
         std::filesystem::remove(test_file);
     }

--- a/test/cpp/test_config_loader.cpp
+++ b/test/cpp/test_config_loader.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include "config_loader.hpp"
+#include "vfs_adapter.hpp"
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <sstream>
 
 using namespace flapi;
@@ -321,5 +323,220 @@ TEST_CASE("ConfigLoader error messages", "[config][loader]") {
             bool has_yaml = error_msg.find("YAML") != std::string::npos;
             REQUIRE((has_parse || has_yaml));
         }
+    }
+}
+
+// ============================================================================
+// VFS Integration Tests
+// ============================================================================
+
+// Mock file provider for testing
+class MockFileProvider : public IFileProvider {
+public:
+    std::map<std::string, std::string> files;
+    mutable std::vector<std::string> read_calls;
+    mutable std::vector<std::string> exists_calls;
+
+    std::string ReadFile(const std::string& path) override {
+        read_calls.push_back(path);
+        auto it = files.find(path);
+        if (it == files.end()) {
+            throw FileOperationError("File not found: " + path);
+        }
+        return it->second;
+    }
+
+    bool FileExists(const std::string& path) override {
+        exists_calls.push_back(path);
+        return files.find(path) != files.end();
+    }
+
+    std::vector<std::string> ListFiles(const std::string& directory,
+                                        const std::string& pattern) override {
+        std::vector<std::string> result;
+        for (const auto& [path, _] : files) {
+            if (path.find(directory) == 0) {
+                result.push_back(path);
+            }
+        }
+        return result;
+    }
+
+    bool IsRemotePath(const std::string& path) const override {
+        return PathSchemeUtils::IsRemotePath(path);
+    }
+
+    std::string GetProviderName() const override {
+        return "mock-provider";
+    }
+};
+
+TEST_CASE("ConfigLoader with custom IFileProvider", "[config][loader][vfs]") {
+    SECTION("Use custom file provider for file operations") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["/config/flapi.yaml"] = "project-name: test";
+        mock_provider->files["/config/endpoints/test.yaml"] = "url-path: /test";
+
+        ConfigLoader loader("/config/flapi.yaml", mock_provider);
+
+        REQUIRE(loader.getFileProvider() == mock_provider);
+        REQUIRE(loader.getConfigFilePathString() == "/config/flapi.yaml");
+    }
+
+    SECTION("Load YAML through custom provider") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        std::string yaml_content = R"(
+project-name: MockProject
+version: "1.0"
+)";
+        mock_provider->files["/config/flapi.yaml"] = yaml_content;
+
+        ConfigLoader loader("/config/flapi.yaml", mock_provider);
+
+        YAML::Node node = loader.loadYamlFile("/config/flapi.yaml");
+
+        REQUIRE(node["project-name"].as<std::string>() == "MockProject");
+        REQUIRE(node["version"].as<std::string>() == "1.0");
+
+        // Verify provider was called
+        REQUIRE(mock_provider->read_calls.size() == 1);
+        REQUIRE(mock_provider->exists_calls.size() == 1);
+    }
+
+    SECTION("File existence check through custom provider") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["/config/flapi.yaml"] = "test";
+        mock_provider->files["/config/test.yaml"] = "test";
+
+        ConfigLoader loader("/config/flapi.yaml", mock_provider);
+
+        REQUIRE(loader.fileExists("/config/test.yaml"));
+        REQUIRE_FALSE(loader.fileExists("/config/nonexistent.yaml"));
+    }
+
+    SECTION("readFile method uses custom provider") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["/config/flapi.yaml"] = "test";
+        mock_provider->files["/config/template.sql"] = "SELECT * FROM users";
+
+        ConfigLoader loader("/config/flapi.yaml", mock_provider);
+
+        std::string content = loader.readFile("/config/template.sql");
+        REQUIRE(content == "SELECT * FROM users");
+    }
+}
+
+TEST_CASE("ConfigLoader remote path detection", "[config][loader][vfs]") {
+    SECTION("isRemoteConfig returns true for S3 paths") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["s3://bucket/config/flapi.yaml"] = "test";
+
+        ConfigLoader loader("s3://bucket/config/flapi.yaml", mock_provider);
+
+        REQUIRE(loader.isRemoteConfig());
+        REQUIRE(loader.getConfigFilePathString() == "s3://bucket/config/flapi.yaml");
+    }
+
+    SECTION("isRemoteConfig returns true for GCS paths") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["gs://bucket/config/flapi.yaml"] = "test";
+
+        ConfigLoader loader("gs://bucket/config/flapi.yaml", mock_provider);
+
+        REQUIRE(loader.isRemoteConfig());
+    }
+
+    SECTION("isRemoteConfig returns true for HTTPS paths") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["https://example.com/config/flapi.yaml"] = "test";
+
+        ConfigLoader loader("https://example.com/config/flapi.yaml", mock_provider);
+
+        REQUIRE(loader.isRemoteConfig());
+    }
+
+    SECTION("isRemoteConfig returns false for local paths") {
+        TempFile config("test");
+        ConfigLoader loader(config.path());
+
+        REQUIRE_FALSE(loader.isRemoteConfig());
+    }
+
+    SECTION("isRemoteConfig returns false for file:// paths") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["/tmp/flapi.yaml"] = "test";
+
+        ConfigLoader loader("file:///tmp/flapi.yaml", mock_provider);
+
+        REQUIRE_FALSE(loader.isRemoteConfig());
+    }
+}
+
+TEST_CASE("ConfigLoader remote path resolution", "[config][loader][vfs]") {
+    SECTION("Resolve relative path with remote base") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["s3://bucket/config/flapi.yaml"] = "test";
+        mock_provider->files["s3://bucket/config/endpoints/test.yaml"] = "test";
+
+        ConfigLoader loader("s3://bucket/config/flapi.yaml", mock_provider);
+
+        auto resolved = loader.resolvePath("endpoints/test.yaml");
+        REQUIRE(resolved.string() == "s3://bucket/config/endpoints/test.yaml");
+    }
+
+    SECTION("Absolute remote paths remain unchanged") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["s3://bucket/config/flapi.yaml"] = "test";
+
+        ConfigLoader loader("s3://bucket/config/flapi.yaml", mock_provider);
+
+        auto resolved = loader.resolvePath("s3://other-bucket/file.yaml");
+        REQUIRE(resolved.string() == "s3://other-bucket/file.yaml");
+    }
+
+    SECTION("Empty path returns base path") {
+        auto mock_provider = std::make_shared<MockFileProvider>();
+        mock_provider->files["s3://bucket/config/flapi.yaml"] = "test";
+
+        ConfigLoader loader("s3://bucket/config/flapi.yaml", mock_provider);
+
+        auto resolved = loader.resolvePath("");
+        REQUIRE(resolved.string() == "s3://bucket/config/");
+    }
+}
+
+TEST_CASE("ConfigLoader backward compatibility", "[config][loader][vfs]") {
+    SECTION("Default constructor creates LocalFileProvider") {
+        TempFile config("test");
+        ConfigLoader loader(config.path());
+
+        auto provider = loader.getFileProvider();
+        REQUIRE(provider != nullptr);
+        REQUIRE(provider->GetProviderName() == "local");
+    }
+
+    SECTION("Local file operations work with default constructor") {
+        std::string yaml_content = R"(
+project-name: LocalProject
+server:
+  port: 8080
+)";
+        TempFile config(yaml_content);
+        ConfigLoader loader(config.path());
+
+        REQUIRE(loader.fileExists(config.path()));
+
+        YAML::Node node = loader.loadYamlFile(config.path());
+        REQUIRE(node["project-name"].as<std::string>() == "LocalProject");
+        REQUIRE(node["server"]["port"].as<int>() == 8080);
+    }
+
+    SECTION("getConfigFilePath returns filesystem path for local configs") {
+        TempFile config("test");
+        ConfigLoader loader(config.path());
+
+        // For local configs, both path methods should work
+        REQUIRE(loader.getConfigFilePath() == config.path());
+        REQUIRE_FALSE(loader.getConfigFilePathString().empty());
     }
 }

--- a/test/cpp/test_path_validator.cpp
+++ b/test/cpp/test_path_validator.cpp
@@ -1,0 +1,440 @@
+#include <catch2/catch_test_macros.hpp>
+#include "path_validator.hpp"
+
+using namespace flapi;
+
+// ============================================================================
+// Path Traversal Attack Prevention Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Path traversal detection", "[security][path_validator]") {
+    SECTION("Detects basic .. traversal") {
+        REQUIRE(PathValidator::ContainsTraversal(".."));
+        REQUIRE(PathValidator::ContainsTraversal("../"));
+        REQUIRE(PathValidator::ContainsTraversal("../file.txt"));
+        REQUIRE(PathValidator::ContainsTraversal("path/../file.txt"));
+        REQUIRE(PathValidator::ContainsTraversal("/path/../file.txt"));
+        REQUIRE(PathValidator::ContainsTraversal("path/to/../file.txt"));
+    }
+
+    SECTION("Detects Windows-style traversal") {
+        REQUIRE(PathValidator::ContainsTraversal("..\\"));
+        REQUIRE(PathValidator::ContainsTraversal("..\\file.txt"));
+        REQUIRE(PathValidator::ContainsTraversal("path\\..\\file.txt"));
+    }
+
+    SECTION("Allows normal paths without traversal") {
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("file.txt"));
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("path/to/file.txt"));
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("/absolute/path/file.txt"));
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("path/file..txt"));  // .. in filename
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("path/...file.txt")); // ... is ok
+        REQUIRE_FALSE(PathValidator::ContainsTraversal("path/.hidden/file.txt")); // .hidden
+    }
+
+    SECTION("Detects traversal at end of path") {
+        REQUIRE(PathValidator::ContainsTraversal("path/.."));
+        REQUIRE(PathValidator::ContainsTraversal("/path/to/.."));
+    }
+}
+
+TEST_CASE("PathValidator: URL-encoded traversal detection", "[security][path_validator]") {
+    PathValidator validator;
+
+    SECTION("Decodes %2e (.) properly") {
+        // %2e%2e = ..
+        auto result = validator.ValidatePath("%2e%2e/etc/passwd", "/base");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("traversal") != std::string::npos);
+    }
+
+    SECTION("Decodes mixed encoding") {
+        // .%2e = ..
+        auto result = validator.ValidatePath(".%2e/etc/passwd", "/base");
+        REQUIRE_FALSE(result.valid);
+    }
+
+    SECTION("Decodes uppercase hex") {
+        // %2E%2E = ..
+        auto result = validator.ValidatePath("%2E%2E/etc/passwd", "/base");
+        REQUIRE_FALSE(result.valid);
+    }
+
+    SECTION("Double-encoded traversal") {
+        // %252e%252e would decode to %2e%2e, then to ..
+        // First decode: %25 = %
+        std::string decoded = PathValidator::UrlDecode("%252e%252e");
+        REQUIRE(decoded == "%2e%2e");
+        // Note: We only decode once, so this is still caught on second validation
+    }
+}
+
+TEST_CASE("PathValidator: URL decode function", "[security][path_validator]") {
+    SECTION("Decodes basic sequences") {
+        REQUIRE(PathValidator::UrlDecode("%20") == " ");
+        REQUIRE(PathValidator::UrlDecode("%2f") == "/");
+        REQUIRE(PathValidator::UrlDecode("%2F") == "/");
+        REQUIRE(PathValidator::UrlDecode("%2e") == ".");
+    }
+
+    SECTION("Decodes full paths") {
+        REQUIRE(PathValidator::UrlDecode("path%2fto%2ffile") == "path/to/file");
+        REQUIRE(PathValidator::UrlDecode("%2e%2e%2fpasswd") == "../passwd");
+    }
+
+    SECTION("Handles + as space") {
+        REQUIRE(PathValidator::UrlDecode("hello+world") == "hello world");
+    }
+
+    SECTION("Preserves non-encoded content") {
+        REQUIRE(PathValidator::UrlDecode("normal-path") == "normal-path");
+        REQUIRE(PathValidator::UrlDecode("/path/to/file.txt") == "/path/to/file.txt");
+    }
+
+    SECTION("Handles incomplete sequences") {
+        REQUIRE(PathValidator::UrlDecode("%2") == "%2");  // Incomplete
+        REQUIRE(PathValidator::UrlDecode("%") == "%");
+        REQUIRE(PathValidator::UrlDecode("%GG") == "%GG");  // Invalid hex
+    }
+}
+
+// ============================================================================
+// Prefix-based Access Control Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Allowed prefix checking", "[security][path_validator]") {
+    PathValidator::Config config;
+    config.allowed_prefixes = {"/allowed/path", "/another/allowed"};
+    PathValidator validator(config);
+
+    SECTION("Allows paths within prefix") {
+        auto result = validator.ValidatePath("/allowed/path/file.txt");
+        REQUIRE(result.valid);
+
+        result = validator.ValidatePath("/allowed/path/subdir/file.txt");
+        REQUIRE(result.valid);
+
+        result = validator.ValidatePath("/another/allowed/file.txt");
+        REQUIRE(result.valid);
+    }
+
+    SECTION("Rejects paths outside prefix") {
+        auto result = validator.ValidatePath("/forbidden/path/file.txt");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("not within allowed") != std::string::npos);
+
+        result = validator.ValidatePath("/etc/passwd");
+        REQUIRE_FALSE(result.valid);
+    }
+
+    SECTION("Allows exact prefix match") {
+        auto result = validator.ValidatePath("/allowed/path");
+        REQUIRE(result.valid);
+    }
+
+    SECTION("Rejects prefix-like but not matching paths") {
+        // /allowed/pathXXX should not match /allowed/path/
+        auto result = validator.ValidatePath("/allowed/pathological/file.txt");
+        REQUIRE_FALSE(result.valid);
+    }
+}
+
+TEST_CASE("PathValidator: No prefix restriction", "[security][path_validator]") {
+    PathValidator::Config config;
+    config.allowed_prefixes = {};  // Empty = allow all
+    PathValidator validator(config);
+
+    SECTION("Allows any path when no prefixes configured") {
+        auto result = validator.ValidatePath("/any/path/file.txt");
+        REQUIRE(result.valid);
+
+        result = validator.ValidatePath("/etc/passwd");
+        REQUIRE(result.valid);
+    }
+}
+
+// ============================================================================
+// URL Scheme Whitelisting Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Scheme whitelisting", "[security][path_validator]") {
+    PathValidator::Config config;
+    config.allowed_schemes = {"https", "file"};
+    PathValidator validator(config);
+
+    SECTION("Allows whitelisted schemes") {
+        REQUIRE(validator.IsSchemeAllowed("https"));
+        REQUIRE(validator.IsSchemeAllowed("file"));
+    }
+
+    SECTION("Rejects non-whitelisted schemes") {
+        REQUIRE_FALSE(validator.IsSchemeAllowed("s3"));
+        REQUIRE_FALSE(validator.IsSchemeAllowed("gs"));
+        REQUIRE_FALSE(validator.IsSchemeAllowed("http"));
+        REQUIRE_FALSE(validator.IsSchemeAllowed("ftp"));
+    }
+
+    SECTION("Validates remote paths with scheme check") {
+        auto result = validator.ValidatePath("https://example.com/file.txt");
+        REQUIRE(result.valid);
+
+        result = validator.ValidatePath("s3://bucket/file.txt");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("scheme not allowed") != std::string::npos);
+    }
+}
+
+TEST_CASE("PathValidator: Adding schemes dynamically", "[security][path_validator]") {
+    PathValidator validator;
+
+    SECTION("Can add S3 scheme") {
+        REQUIRE_FALSE(validator.IsSchemeAllowed("s3"));
+
+        validator.AddAllowedScheme("s3");
+
+        REQUIRE(validator.IsSchemeAllowed("s3"));
+
+        auto result = validator.ValidatePath("s3://bucket/key.txt");
+        REQUIRE(result.valid);
+    }
+
+    SECTION("Can add multiple schemes") {
+        validator.AddAllowedScheme("s3");
+        validator.AddAllowedScheme("gs");
+        validator.AddAllowedScheme("az");
+
+        REQUIRE(validator.IsSchemeAllowed("s3"));
+        REQUIRE(validator.IsSchemeAllowed("gs"));
+        REQUIRE(validator.IsSchemeAllowed("az"));
+    }
+}
+
+TEST_CASE("PathValidator: Scheme extraction", "[security][path_validator]") {
+    SECTION("Extracts common schemes") {
+        REQUIRE(PathValidator::ExtractScheme("https://example.com") == "https");
+        REQUIRE(PathValidator::ExtractScheme("http://example.com") == "http");
+        REQUIRE(PathValidator::ExtractScheme("s3://bucket/key") == "s3");
+        REQUIRE(PathValidator::ExtractScheme("gs://bucket/key") == "gs");
+        REQUIRE(PathValidator::ExtractScheme("file:///path") == "file");
+    }
+
+    SECTION("Returns empty for no scheme") {
+        REQUIRE(PathValidator::ExtractScheme("/local/path") == "");
+        REQUIRE(PathValidator::ExtractScheme("relative/path") == "");
+        REQUIRE(PathValidator::ExtractScheme("") == "");
+    }
+
+    SECTION("Handles case insensitively") {
+        REQUIRE(PathValidator::ExtractScheme("HTTPS://example.com") == "https");
+        REQUIRE(PathValidator::ExtractScheme("S3://bucket/key") == "s3");
+    }
+
+    SECTION("Rejects invalid schemes") {
+        REQUIRE(PathValidator::ExtractScheme("://no-scheme") == "");
+        REQUIRE(PathValidator::ExtractScheme("bad scheme://host") == "");
+    }
+}
+
+// ============================================================================
+// Path Canonicalization Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Path canonicalization", "[security][path_validator]") {
+    PathValidator validator;
+
+    SECTION("Combines base and relative paths") {
+        std::string result = validator.Canonicalize("/base/path", "file.txt");
+        REQUIRE(result == "/base/path/file.txt");
+
+        result = validator.Canonicalize("/base/path/", "file.txt");
+        REQUIRE(result == "/base/path/file.txt");
+    }
+
+    SECTION("Handles ./ prefix") {
+        std::string result = validator.Canonicalize("/base", "./file.txt");
+        REQUIRE(result == "/base/file.txt");
+    }
+
+    SECTION("Returns empty for traversal") {
+        std::string result = validator.Canonicalize("/base", "../file.txt");
+        REQUIRE(result == "");
+
+        result = validator.Canonicalize("/base", "sub/../../../etc/passwd");
+        REQUIRE(result == "");
+    }
+
+    SECTION("Normalizes Windows separators") {
+        std::string result = validator.Canonicalize("C:\\base\\path", "file.txt");
+        REQUIRE(result == "C:/base/path/file.txt");
+    }
+
+    SECTION("Removes duplicate slashes") {
+        std::string result = validator.Canonicalize("/base//path", "file.txt");
+        REQUIRE(result == "/base/path/file.txt");
+    }
+}
+
+// ============================================================================
+// Remote Path Detection Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Remote path detection", "[security][path_validator]") {
+    SECTION("Identifies remote schemes") {
+        REQUIRE(PathValidator::IsRemotePath("s3://bucket/key"));
+        REQUIRE(PathValidator::IsRemotePath("gs://bucket/key"));
+        REQUIRE(PathValidator::IsRemotePath("https://example.com/path"));
+        REQUIRE(PathValidator::IsRemotePath("http://example.com/path"));
+        REQUIRE(PathValidator::IsRemotePath("az://container/blob"));
+        REQUIRE(PathValidator::IsRemotePath("abfs://container@account/path"));
+    }
+
+    SECTION("Identifies local paths") {
+        REQUIRE_FALSE(PathValidator::IsRemotePath("/local/path"));
+        REQUIRE_FALSE(PathValidator::IsRemotePath("relative/path"));
+        REQUIRE_FALSE(PathValidator::IsRemotePath("file:///local/path"));
+        REQUIRE_FALSE(PathValidator::IsRemotePath("C:\\Windows\\path"));
+    }
+}
+
+// ============================================================================
+// Full Validation Flow Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: Full validation scenarios", "[security][path_validator]") {
+    PathValidator::Config config;
+    config.allowed_schemes = {"https", "s3"};
+    config.allowed_prefixes = {"/app/data", "/app/templates"};
+    PathValidator validator(config);
+
+    SECTION("Valid local path within allowed prefix") {
+        auto result = validator.ValidatePath("/app/data/users.json");
+        REQUIRE(result.valid);
+        REQUIRE(result.canonical_path == "/app/data/users.json");
+    }
+
+    SECTION("Valid relative path resolved against base") {
+        auto result = validator.ValidatePath("users.json", "/app/data");
+        REQUIRE(result.valid);
+        REQUIRE(result.canonical_path == "/app/data/users.json");
+    }
+
+    SECTION("Valid HTTPS URL") {
+        auto result = validator.ValidatePath("https://api.example.com/data.json");
+        REQUIRE(result.valid);
+    }
+
+    SECTION("Valid S3 URL after adding scheme") {
+        auto result = validator.ValidatePath("s3://mybucket/data/file.json");
+        REQUIRE(result.valid);
+    }
+
+    SECTION("Rejects traversal attempt") {
+        auto result = validator.ValidatePath("../../../etc/passwd", "/app/data");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("traversal") != std::string::npos);
+    }
+
+    SECTION("Rejects path outside allowed prefix") {
+        auto result = validator.ValidatePath("/etc/passwd");
+        REQUIRE_FALSE(result.valid);
+    }
+
+    SECTION("Rejects disallowed scheme") {
+        auto result = validator.ValidatePath("ftp://server/file.txt");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("scheme not allowed") != std::string::npos);
+    }
+}
+
+TEST_CASE("PathValidator: Empty and edge cases", "[security][path_validator]") {
+    PathValidator validator;
+
+    SECTION("Rejects empty path") {
+        auto result = validator.ValidatePath("");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("empty") != std::string::npos);
+    }
+
+    SECTION("Handles whitespace-only paths") {
+        auto result = validator.ValidatePath("   ");
+        // After URL decode, this is just spaces - should fail as not useful
+        REQUIRE_FALSE(result.valid);
+    }
+}
+
+// ============================================================================
+// OWASP Path Traversal Pattern Tests
+// ============================================================================
+
+TEST_CASE("PathValidator: OWASP path traversal patterns", "[security][path_validator]") {
+    PathValidator::Config config;
+    config.allowed_prefixes = {"/safe"};
+    PathValidator validator(config);
+
+    // Test patterns from OWASP Path Traversal cheat sheet
+    SECTION("Basic traversal patterns") {
+        REQUIRE_FALSE(validator.ValidatePath("../../../etc/passwd", "/safe").valid);
+        REQUIRE_FALSE(validator.ValidatePath("..\\..\\..\\windows\\system32", "/safe").valid);
+    }
+
+    SECTION("URL-encoded traversal") {
+        REQUIRE_FALSE(validator.ValidatePath("%2e%2e/%2e%2e/etc/passwd", "/safe").valid);
+        REQUIRE_FALSE(validator.ValidatePath("..%2f..%2f..%2fetc/passwd", "/safe").valid);
+        REQUIRE_FALSE(validator.ValidatePath("%2e%2e%5c..%5c..%5cwindows", "/safe").valid);
+    }
+
+    SECTION("Double URL-encoding") {
+        // %252e = %2e after first decode, which is . after second decode
+        // We only decode once, but the first decode should reveal suspicious patterns
+        std::string first_decode = PathValidator::UrlDecode("%252e%252e");
+        REQUIRE(first_decode == "%2e%2e");
+    }
+
+    SECTION("Null byte injection (legacy)") {
+        // %00 null byte - should be decoded and path should still be validated
+        auto result = validator.ValidatePath("/safe/file.txt%00.jpg", "/safe");
+        // Path is within /safe, so it's allowed
+        REQUIRE(result.valid);
+        // The null byte becomes \0 in the string but path is still under /safe
+    }
+
+    SECTION("Unicode/UTF-8 encoding attacks") {
+        // Overlong UTF-8 encoding of / (%c0%af)
+        // This should be treated as literal characters since we do basic URL decode
+        auto result = validator.ValidatePath("%c0%af", "/safe");
+        // This decodes to invalid UTF-8, treated as literal
+        REQUIRE(result.valid);  // No traversal detected
+    }
+}
+
+TEST_CASE("PathValidator: Configuration validation", "[security][path_validator]") {
+    SECTION("Default config allows file and https") {
+        PathValidator validator;
+        const auto& config = validator.GetConfig();
+
+        REQUIRE(config.allowed_schemes.count("file") == 1);
+        REQUIRE(config.allowed_schemes.count("https") == 1);
+        REQUIRE(config.allow_local_paths == true);
+        REQUIRE(config.allow_relative_paths == true);
+    }
+
+    SECTION("Can disable local paths") {
+        PathValidator::Config config;
+        config.allow_local_paths = false;
+        PathValidator validator(config);
+
+        auto result = validator.ValidatePath("/local/path");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("Local paths not allowed") != std::string::npos);
+    }
+
+    SECTION("Can disable relative paths") {
+        PathValidator::Config config;
+        config.allow_relative_paths = false;
+        PathValidator validator(config);
+
+        auto result = validator.ValidatePath("relative/path", "/base");
+        REQUIRE_FALSE(result.valid);
+        REQUIRE(result.error_message.find("Relative paths not allowed") != std::string::npos);
+    }
+}

--- a/test/cpp/test_vfs_adapter.cpp
+++ b/test/cpp/test_vfs_adapter.cpp
@@ -1,0 +1,498 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include "vfs_adapter.hpp"
+#include <filesystem>
+#include <fstream>
+
+using namespace flapi;
+
+// Helper to create temporary test files
+class TempTestFile {
+public:
+    explicit TempTestFile(const std::string& content = "",
+                          const std::string& extension = ".txt") {
+        path_ = std::filesystem::temp_directory_path() /
+                ("vfs_test_" + std::to_string(reinterpret_cast<uintptr_t>(this)) + extension);
+        // Always create the file, even if content is empty
+        std::ofstream file(path_);
+        file << content;
+    }
+
+    ~TempTestFile() {
+        if (std::filesystem::exists(path_)) {
+            std::filesystem::remove(path_);
+        }
+    }
+
+    std::filesystem::path path() const { return path_; }
+    std::string pathString() const { return path_.string(); }
+
+private:
+    std::filesystem::path path_;
+};
+
+// Helper to create temporary test directories
+class TempTestDir {
+public:
+    TempTestDir() {
+        path_ = std::filesystem::temp_directory_path() /
+                ("vfs_test_dir_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempTestDir() {
+        if (std::filesystem::exists(path_)) {
+            std::filesystem::remove_all(path_);
+        }
+    }
+
+    std::filesystem::path path() const { return path_; }
+    std::string pathString() const { return path_.string(); }
+
+    void createFile(const std::string& name, const std::string& content = "") {
+        std::ofstream file(path_ / name);
+        file << content;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+// ============================================================================
+// PathSchemeUtils Tests
+// ============================================================================
+
+TEST_CASE("PathSchemeUtils::IsRemotePath", "[vfs][scheme]") {
+    SECTION("S3 paths are remote") {
+        REQUIRE(PathSchemeUtils::IsRemotePath("s3://bucket/key"));
+        REQUIRE(PathSchemeUtils::IsRemotePath("s3://my-bucket/path/to/file.yaml"));
+    }
+
+    SECTION("GCS paths are remote") {
+        REQUIRE(PathSchemeUtils::IsRemotePath("gs://bucket/key"));
+        REQUIRE(PathSchemeUtils::IsRemotePath("gs://my-bucket/path/to/file.yaml"));
+    }
+
+    SECTION("Azure paths are remote") {
+        REQUIRE(PathSchemeUtils::IsRemotePath("az://container/blob"));
+        REQUIRE(PathSchemeUtils::IsRemotePath("azure://container/blob"));
+    }
+
+    SECTION("HTTP/HTTPS paths are remote") {
+        REQUIRE(PathSchemeUtils::IsRemotePath("http://example.com/file.yaml"));
+        REQUIRE(PathSchemeUtils::IsRemotePath("https://example.com/file.yaml"));
+    }
+
+    SECTION("Local paths are not remote") {
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath("/local/path/file.yaml"));
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath("./relative/path.yaml"));
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath("relative/path.yaml"));
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath("file.yaml"));
+    }
+
+    SECTION("file:// scheme is not remote") {
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath("file:///local/path/file.yaml"));
+    }
+
+    SECTION("Empty path is not remote") {
+        REQUIRE_FALSE(PathSchemeUtils::IsRemotePath(""));
+    }
+}
+
+TEST_CASE("PathSchemeUtils::IsS3Path", "[vfs][scheme]") {
+    REQUIRE(PathSchemeUtils::IsS3Path("s3://bucket/key"));
+    REQUIRE(PathSchemeUtils::IsS3Path("s3://"));
+    REQUIRE_FALSE(PathSchemeUtils::IsS3Path("S3://bucket/key")); // Case sensitive
+    REQUIRE_FALSE(PathSchemeUtils::IsS3Path("gs://bucket/key"));
+    REQUIRE_FALSE(PathSchemeUtils::IsS3Path("/local/path"));
+}
+
+TEST_CASE("PathSchemeUtils::IsGCSPath", "[vfs][scheme]") {
+    REQUIRE(PathSchemeUtils::IsGCSPath("gs://bucket/key"));
+    REQUIRE(PathSchemeUtils::IsGCSPath("gs://"));
+    REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("GS://bucket/key")); // Case sensitive
+    REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("s3://bucket/key"));
+    REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("/local/path"));
+}
+
+TEST_CASE("PathSchemeUtils::IsAzurePath", "[vfs][scheme]") {
+    REQUIRE(PathSchemeUtils::IsAzurePath("az://container/blob"));
+    REQUIRE(PathSchemeUtils::IsAzurePath("azure://container/blob"));
+    REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("AZ://container/blob")); // Case sensitive
+    REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("s3://bucket/key"));
+    REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("/local/path"));
+}
+
+TEST_CASE("PathSchemeUtils::IsHttpPath", "[vfs][scheme]") {
+    REQUIRE(PathSchemeUtils::IsHttpPath("http://example.com/file"));
+    REQUIRE(PathSchemeUtils::IsHttpPath("https://example.com/file"));
+    REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("HTTP://example.com")); // Case sensitive
+    REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("ftp://example.com/file"));
+    REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("/local/path"));
+}
+
+TEST_CASE("PathSchemeUtils::IsFilePath", "[vfs][scheme]") {
+    REQUIRE(PathSchemeUtils::IsFilePath("file:///local/path"));
+    REQUIRE(PathSchemeUtils::IsFilePath("file://relative/path"));
+    REQUIRE_FALSE(PathSchemeUtils::IsFilePath("FILE:///local/path")); // Case sensitive
+    REQUIRE_FALSE(PathSchemeUtils::IsFilePath("/local/path"));
+    REQUIRE_FALSE(PathSchemeUtils::IsFilePath("s3://bucket/key"));
+}
+
+TEST_CASE("PathSchemeUtils::GetScheme", "[vfs][scheme]") {
+    SECTION("Returns correct scheme for each type") {
+        REQUIRE(PathSchemeUtils::GetScheme("s3://bucket/key") == "s3://");
+        REQUIRE(PathSchemeUtils::GetScheme("gs://bucket/key") == "gs://");
+        REQUIRE(PathSchemeUtils::GetScheme("az://container/blob") == "az://");
+        REQUIRE(PathSchemeUtils::GetScheme("azure://container/blob") == "azure://");
+        REQUIRE(PathSchemeUtils::GetScheme("http://example.com") == "http://");
+        REQUIRE(PathSchemeUtils::GetScheme("https://example.com") == "https://");
+        REQUIRE(PathSchemeUtils::GetScheme("file:///local/path") == "file://");
+    }
+
+    SECTION("Returns empty string for local paths") {
+        REQUIRE(PathSchemeUtils::GetScheme("/local/path") == "");
+        REQUIRE(PathSchemeUtils::GetScheme("relative/path") == "");
+        REQUIRE(PathSchemeUtils::GetScheme("") == "");
+    }
+}
+
+TEST_CASE("PathSchemeUtils::StripFileScheme", "[vfs][scheme]") {
+    SECTION("Strips file:// prefix") {
+        REQUIRE(PathSchemeUtils::StripFileScheme("file:///local/path") == "/local/path");
+        REQUIRE(PathSchemeUtils::StripFileScheme("file://relative") == "relative");
+    }
+
+    SECTION("Returns unchanged for non-file paths") {
+        REQUIRE(PathSchemeUtils::StripFileScheme("/local/path") == "/local/path");
+        REQUIRE(PathSchemeUtils::StripFileScheme("s3://bucket/key") == "s3://bucket/key");
+        REQUIRE(PathSchemeUtils::StripFileScheme("relative") == "relative");
+    }
+}
+
+// ============================================================================
+// LocalFileProvider Tests
+// ============================================================================
+
+TEST_CASE("LocalFileProvider::GetProviderName", "[vfs][local]") {
+    LocalFileProvider provider;
+    REQUIRE(provider.GetProviderName() == "local");
+}
+
+TEST_CASE("LocalFileProvider::IsRemotePath", "[vfs][local]") {
+    LocalFileProvider provider;
+
+    SECTION("Local paths are not remote") {
+        REQUIRE_FALSE(provider.IsRemotePath("/local/path"));
+        REQUIRE_FALSE(provider.IsRemotePath("./relative/path"));
+        REQUIRE_FALSE(provider.IsRemotePath("file.txt"));
+    }
+
+    SECTION("Remote paths are identified") {
+        REQUIRE(provider.IsRemotePath("s3://bucket/key"));
+        REQUIRE(provider.IsRemotePath("https://example.com/file"));
+    }
+}
+
+TEST_CASE("LocalFileProvider::ReadFile", "[vfs][local]") {
+    LocalFileProvider provider;
+
+    SECTION("Read existing file") {
+        TempTestFile file("Hello, World!");
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == "Hello, World!");
+    }
+
+    SECTION("Read file with multiple lines") {
+        TempTestFile file("Line 1\nLine 2\nLine 3");
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == "Line 1\nLine 2\nLine 3");
+    }
+
+    SECTION("Read empty file") {
+        TempTestFile file("");
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content.empty());
+    }
+
+    SECTION("Read YAML content") {
+        std::string yaml = "project-name: test\nversion: 1.0.0\n";
+        TempTestFile file(yaml, ".yaml");
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == yaml);
+    }
+
+    SECTION("Read file with file:// scheme") {
+        TempTestFile file("Content with file scheme");
+        std::string file_uri = "file://" + file.pathString();
+        std::string content = provider.ReadFile(file_uri);
+        REQUIRE(content == "Content with file scheme");
+    }
+
+    SECTION("Throw on non-existent file") {
+        REQUIRE_THROWS_AS(
+            provider.ReadFile("/nonexistent/path/file.txt"),
+            FileOperationError
+        );
+    }
+
+    SECTION("Error message includes file path") {
+        try {
+            provider.ReadFile("/nonexistent/path/file.txt");
+            REQUIRE(false); // Should not reach here
+        } catch (const FileOperationError& e) {
+            REQUIRE(std::string(e.what()).find("nonexistent") != std::string::npos);
+        }
+    }
+}
+
+TEST_CASE("LocalFileProvider::FileExists", "[vfs][local]") {
+    LocalFileProvider provider;
+
+    SECTION("Returns true for existing file") {
+        TempTestFile file("test content");
+        REQUIRE(provider.FileExists(file.pathString()));
+    }
+
+    SECTION("Returns false for non-existent file") {
+        REQUIRE_FALSE(provider.FileExists("/nonexistent/path/file.txt"));
+    }
+
+    SECTION("Returns false for directory") {
+        TempTestDir dir;
+        REQUIRE_FALSE(provider.FileExists(dir.pathString()));
+    }
+
+    SECTION("Returns false for remote paths") {
+        REQUIRE_FALSE(provider.FileExists("s3://bucket/key"));
+        REQUIRE_FALSE(provider.FileExists("https://example.com/file"));
+    }
+
+    SECTION("Handles file:// scheme") {
+        TempTestFile file("test content");
+        std::string file_uri = "file://" + file.pathString();
+        REQUIRE(provider.FileExists(file_uri));
+    }
+}
+
+TEST_CASE("LocalFileProvider::ListFiles", "[vfs][local]") {
+    LocalFileProvider provider;
+
+    SECTION("List files matching pattern") {
+        TempTestDir dir;
+        dir.createFile("file1.yaml", "content1");
+        dir.createFile("file2.yaml", "content2");
+        dir.createFile("file3.txt", "content3");
+
+        auto yaml_files = provider.ListFiles(dir.pathString(), "*.yaml");
+        REQUIRE(yaml_files.size() == 2);
+
+        // Check that both yaml files are found
+        bool found_file1 = false, found_file2 = false;
+        for (const auto& f : yaml_files) {
+            if (f.find("file1.yaml") != std::string::npos) {
+                found_file1 = true;
+            }
+            if (f.find("file2.yaml") != std::string::npos) {
+                found_file2 = true;
+            }
+        }
+        REQUIRE(found_file1);
+        REQUIRE(found_file2);
+    }
+
+    SECTION("List all files with wildcard") {
+        TempTestDir dir;
+        dir.createFile("file1.yaml", "content1");
+        dir.createFile("file2.txt", "content2");
+        dir.createFile("file3.sql", "content3");
+
+        auto all_files = provider.ListFiles(dir.pathString(), "*");
+        REQUIRE(all_files.size() == 3);
+    }
+
+    SECTION("Empty directory returns empty list") {
+        TempTestDir dir;
+        auto files = provider.ListFiles(dir.pathString(), "*.yaml");
+        REQUIRE(files.empty());
+    }
+
+    SECTION("No matching files returns empty list") {
+        TempTestDir dir;
+        dir.createFile("file.txt", "content");
+
+        auto files = provider.ListFiles(dir.pathString(), "*.yaml");
+        REQUIRE(files.empty());
+    }
+
+    SECTION("Throw on non-existent directory") {
+        REQUIRE_THROWS_AS(
+            provider.ListFiles("/nonexistent/directory", "*"),
+            FileOperationError
+        );
+    }
+
+    SECTION("Pattern with question mark matches single character") {
+        TempTestDir dir;
+        dir.createFile("file1.txt", "");
+        dir.createFile("file2.txt", "");
+        dir.createFile("file10.txt", "");
+
+        auto files = provider.ListFiles(dir.pathString(), "file?.txt");
+        REQUIRE(files.size() == 2); // file1.txt and file2.txt, not file10.txt
+    }
+
+    SECTION("Results are sorted") {
+        TempTestDir dir;
+        dir.createFile("c.txt", "");
+        dir.createFile("a.txt", "");
+        dir.createFile("b.txt", "");
+
+        auto files = provider.ListFiles(dir.pathString(), "*.txt");
+        REQUIRE(files.size() == 3);
+
+        // Check sorted order
+        REQUIRE(files[0].find("a.txt") != std::string::npos);
+        REQUIRE(files[1].find("b.txt") != std::string::npos);
+        REQUIRE(files[2].find("c.txt") != std::string::npos);
+    }
+
+    SECTION("Handles file:// scheme for directory") {
+        TempTestDir dir;
+        dir.createFile("test.yaml", "content");
+
+        std::string dir_uri = "file://" + dir.pathString();
+        auto files = provider.ListFiles(dir_uri, "*.yaml");
+        REQUIRE(files.size() == 1);
+    }
+}
+
+// ============================================================================
+// FileProviderFactory Tests
+// ============================================================================
+
+TEST_CASE("FileProviderFactory::CreateLocalProvider", "[vfs][factory]") {
+    auto provider = FileProviderFactory::CreateLocalProvider();
+    REQUIRE(provider != nullptr);
+    REQUIRE(provider->GetProviderName() == "local");
+}
+
+TEST_CASE("FileProviderFactory::CreateProvider", "[vfs][factory]") {
+    SECTION("Returns local provider for local paths") {
+        auto provider = FileProviderFactory::CreateProvider("/local/path/file.yaml");
+        REQUIRE(provider != nullptr);
+        REQUIRE(provider->GetProviderName() == "local");
+    }
+
+    SECTION("Returns local provider for relative paths") {
+        auto provider = FileProviderFactory::CreateProvider("relative/path.yaml");
+        REQUIRE(provider != nullptr);
+        REQUIRE(provider->GetProviderName() == "local");
+    }
+
+    SECTION("Returns local provider for file:// paths") {
+        auto provider = FileProviderFactory::CreateProvider("file:///local/path");
+        REQUIRE(provider != nullptr);
+        REQUIRE(provider->GetProviderName() == "local");
+    }
+
+    SECTION("Throws for S3 paths (not yet implemented)") {
+        REQUIRE_THROWS_AS(
+            FileProviderFactory::CreateProvider("s3://bucket/key"),
+            FileOperationError
+        );
+    }
+
+    SECTION("Throws for HTTPS paths (not yet implemented)") {
+        REQUIRE_THROWS_AS(
+            FileProviderFactory::CreateProvider("https://example.com/file"),
+            FileOperationError
+        );
+    }
+
+    SECTION("Error message mentions DuckDBVFSProvider") {
+        try {
+            FileProviderFactory::CreateProvider("s3://bucket/key");
+            REQUIRE(false); // Should not reach here
+        } catch (const FileOperationError& e) {
+            std::string msg(e.what());
+            REQUIRE(msg.find("DuckDBVFSProvider") != std::string::npos);
+        }
+    }
+}
+
+// ============================================================================
+// IFileProvider Interface Contract Tests
+// ============================================================================
+
+TEST_CASE("IFileProvider interface contract", "[vfs][interface]") {
+    // This test verifies that LocalFileProvider correctly implements IFileProvider
+
+    std::shared_ptr<IFileProvider> provider = std::make_shared<LocalFileProvider>();
+
+    SECTION("Can be used through interface pointer") {
+        TempTestFile file("Interface test content");
+
+        std::string content = provider->ReadFile(file.pathString());
+        REQUIRE(content == "Interface test content");
+
+        REQUIRE(provider->FileExists(file.pathString()));
+        REQUIRE_FALSE(provider->FileExists("/nonexistent"));
+
+        REQUIRE_FALSE(provider->IsRemotePath(file.pathString()));
+        REQUIRE(provider->IsRemotePath("s3://bucket/key"));
+    }
+
+    SECTION("ListFiles through interface") {
+        TempTestDir dir;
+        dir.createFile("test.yaml", "content");
+
+        auto files = provider->ListFiles(dir.pathString(), "*.yaml");
+        REQUIRE(files.size() == 1);
+    }
+}
+
+// ============================================================================
+// Edge Cases and Error Handling
+// ============================================================================
+
+TEST_CASE("VFS edge cases", "[vfs][edge]") {
+    LocalFileProvider provider;
+
+    SECTION("Handle paths with spaces") {
+        // Create temp directory with space in name
+        auto temp_dir = std::filesystem::temp_directory_path() / "vfs test dir";
+        std::filesystem::create_directories(temp_dir);
+        auto file_path = temp_dir / "file with spaces.txt";
+        std::ofstream(file_path) << "content with spaces";
+
+        REQUIRE(provider.FileExists(file_path.string()));
+        REQUIRE(provider.ReadFile(file_path.string()) == "content with spaces");
+
+        std::filesystem::remove_all(temp_dir);
+    }
+
+    SECTION("Handle special characters in content") {
+        std::string special_content = "SELECT * FROM table WHERE name = 'O''Brien' AND value > 0;";
+        TempTestFile file(special_content);
+
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == special_content);
+    }
+
+    SECTION("Handle binary-like content") {
+        std::string binary_like = std::string("line1\0line2", 11);
+        TempTestFile file(binary_like);
+
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == binary_like);
+    }
+
+    SECTION("Handle unicode content") {
+        std::string unicode_content = "Hello 世界 🌍 مرحبا";
+        TempTestFile file(unicode_content);
+
+        std::string content = provider.ReadFile(file.pathString());
+        REQUIRE(content == unicode_content);
+    }
+}

--- a/test/cpp/test_vfs_adapter.cpp
+++ b/test/cpp/test_vfs_adapter.cpp
@@ -102,7 +102,8 @@ TEST_CASE("PathSchemeUtils::IsRemotePath", "[vfs][scheme]") {
 TEST_CASE("PathSchemeUtils::IsS3Path", "[vfs][scheme]") {
     REQUIRE(PathSchemeUtils::IsS3Path("s3://bucket/key"));
     REQUIRE(PathSchemeUtils::IsS3Path("s3://"));
-    REQUIRE_FALSE(PathSchemeUtils::IsS3Path("S3://bucket/key")); // Case sensitive
+    REQUIRE(PathSchemeUtils::IsS3Path("S3://bucket/key")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsS3Path("S3://BUCKET/KEY")); // Mixed case
     REQUIRE_FALSE(PathSchemeUtils::IsS3Path("gs://bucket/key"));
     REQUIRE_FALSE(PathSchemeUtils::IsS3Path("/local/path"));
 }
@@ -110,7 +111,8 @@ TEST_CASE("PathSchemeUtils::IsS3Path", "[vfs][scheme]") {
 TEST_CASE("PathSchemeUtils::IsGCSPath", "[vfs][scheme]") {
     REQUIRE(PathSchemeUtils::IsGCSPath("gs://bucket/key"));
     REQUIRE(PathSchemeUtils::IsGCSPath("gs://"));
-    REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("GS://bucket/key")); // Case sensitive
+    REQUIRE(PathSchemeUtils::IsGCSPath("GS://bucket/key")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsGCSPath("Gs://BUCKET/key")); // Mixed case
     REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("s3://bucket/key"));
     REQUIRE_FALSE(PathSchemeUtils::IsGCSPath("/local/path"));
 }
@@ -118,7 +120,9 @@ TEST_CASE("PathSchemeUtils::IsGCSPath", "[vfs][scheme]") {
 TEST_CASE("PathSchemeUtils::IsAzurePath", "[vfs][scheme]") {
     REQUIRE(PathSchemeUtils::IsAzurePath("az://container/blob"));
     REQUIRE(PathSchemeUtils::IsAzurePath("azure://container/blob"));
-    REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("AZ://container/blob")); // Case sensitive
+    REQUIRE(PathSchemeUtils::IsAzurePath("AZ://container/blob")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsAzurePath("AZURE://container/blob")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsAzurePath("Azure://Container/Blob")); // Mixed case
     REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("s3://bucket/key"));
     REQUIRE_FALSE(PathSchemeUtils::IsAzurePath("/local/path"));
 }
@@ -126,7 +130,9 @@ TEST_CASE("PathSchemeUtils::IsAzurePath", "[vfs][scheme]") {
 TEST_CASE("PathSchemeUtils::IsHttpPath", "[vfs][scheme]") {
     REQUIRE(PathSchemeUtils::IsHttpPath("http://example.com/file"));
     REQUIRE(PathSchemeUtils::IsHttpPath("https://example.com/file"));
-    REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("HTTP://example.com")); // Case sensitive
+    REQUIRE(PathSchemeUtils::IsHttpPath("HTTP://example.com")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsHttpPath("HTTPS://example.com")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsHttpPath("Http://Example.COM/file")); // Mixed case
     REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("ftp://example.com/file"));
     REQUIRE_FALSE(PathSchemeUtils::IsHttpPath("/local/path"));
 }
@@ -134,7 +140,8 @@ TEST_CASE("PathSchemeUtils::IsHttpPath", "[vfs][scheme]") {
 TEST_CASE("PathSchemeUtils::IsFilePath", "[vfs][scheme]") {
     REQUIRE(PathSchemeUtils::IsFilePath("file:///local/path"));
     REQUIRE(PathSchemeUtils::IsFilePath("file://relative/path"));
-    REQUIRE_FALSE(PathSchemeUtils::IsFilePath("FILE:///local/path")); // Case sensitive
+    REQUIRE(PathSchemeUtils::IsFilePath("FILE:///local/path")); // Case insensitive
+    REQUIRE(PathSchemeUtils::IsFilePath("File:///local/path")); // Mixed case
     REQUIRE_FALSE(PathSchemeUtils::IsFilePath("/local/path"));
     REQUIRE_FALSE(PathSchemeUtils::IsFilePath("s3://bucket/key"));
 }

--- a/test/integration/test_vfs_e2e.py
+++ b/test/integration/test_vfs_e2e.py
@@ -1,0 +1,428 @@
+"""
+VFS (Virtual File System) End-to-End Integration Tests
+
+Tests the VFS abstraction feature that enables loading configuration
+and SQL template files from remote storage (HTTPS, S3, etc.).
+
+Test Scenarios:
+1. Local path loading (baseline - existing behavior)
+2. HTTPS config loading via DuckDB httpfs extension
+3. Mixed local/remote paths
+4. Error handling for unreachable remote URLs
+5. Path validation security tests
+
+Note: S3 tests require LocalStack and are marked for CI-only execution.
+"""
+
+import pytest
+import subprocess
+import tempfile
+import os
+import time
+import signal
+import yaml
+import pathlib
+import socket
+import http.server
+import threading
+
+
+def get_flapi_binary():
+    """Get the path to the flapi binary based on build type."""
+    current_dir = pathlib.Path(__file__).parent
+    build_type = os.getenv("FLAPI_BUILD_TYPE", "debug").lower()
+
+    for build_dir in [build_type, "debug", "release"]:
+        binary_path = current_dir.parent.parent / "build" / build_dir / "flapi"
+        if binary_path.exists():
+            return binary_path
+
+    pytest.skip("flapi binary not found")
+
+
+def find_free_port():
+    """Find a free port on the local machine."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+    return port
+
+
+class SimpleHTTPHandler(http.server.SimpleHTTPRequestHandler):
+    """Simple HTTP handler that serves files from a specified directory."""
+
+    def __init__(self, *args, directory=None, **kwargs):
+        self.directory = directory or os.getcwd()
+        super().__init__(*args, directory=self.directory, **kwargs)
+
+    def log_message(self, format, *args):
+        """Suppress logging unless debugging."""
+        pass
+
+
+class TestVFSLocalBaseline:
+    """Baseline tests for local file system paths (existing behavior)."""
+
+    @pytest.fixture
+    def temp_config_dir(self):
+        """Create a temporary directory with basic config structure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sqls_dir = os.path.join(tmpdir, "sqls")
+            os.makedirs(sqls_dir)
+            yield tmpdir
+
+    def write_config(self, config_dir: str, config: dict) -> str:
+        """Write config YAML and return its path."""
+        config_path = os.path.join(config_dir, "flapi.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+        return config_path
+
+    def write_endpoint(self, sqls_dir: str, name: str, endpoint: dict, template: str):
+        """Write endpoint YAML and SQL template."""
+        endpoint_path = os.path.join(sqls_dir, f"{name}.yaml")
+        template_path = os.path.join(sqls_dir, f"{name}.sql")
+
+        with open(endpoint_path, "w") as f:
+            yaml.dump(endpoint, f)
+        with open(template_path, "w") as f:
+            f.write(template)
+
+        return endpoint_path, template_path
+
+    def test_local_config_validates(self, temp_config_dir):
+        """Test that local file config validates successfully."""
+        flapi_binary = get_flapi_binary()
+
+        config = {
+            "project-name": "vfs-test",
+            "project-description": "VFS integration test",
+            "http-port": 8080,
+            "template": {"path": "./sqls"},
+            "connections": {
+                "test": {"properties": {"path": "./data.parquet"}}
+            }
+        }
+
+        config_path = self.write_config(temp_config_dir, config)
+
+        result = subprocess.run(
+            [str(flapi_binary), "-c", config_path, "--validate-config"],
+            capture_output=True,
+            text=True,
+            cwd=temp_config_dir
+        )
+
+        assert result.returncode == 0, f"Validation failed: {result.stderr}"
+
+    def test_local_endpoint_loads(self, temp_config_dir):
+        """Test that local endpoint with SQL template loads correctly."""
+        flapi_binary = get_flapi_binary()
+        sqls_dir = os.path.join(temp_config_dir, "sqls")
+
+        config = {
+            "project-name": "vfs-endpoint-test",
+            "project-description": "VFS endpoint test",
+            "http-port": 8080,
+            "template": {"path": "./sqls"},
+            "connections": {
+                "test": {"properties": {"path": "./data.parquet"}}
+            }
+        }
+
+        endpoint = {
+            "url-path": "/test",
+            "method": "GET",
+            "template-source": "test.sql",
+            "connection": ["test"]
+        }
+
+        template = "SELECT 1 as value"
+
+        self.write_config(temp_config_dir, config)
+        self.write_endpoint(sqls_dir, "test", endpoint, template)
+
+        result = subprocess.run(
+            [str(flapi_binary), "-c", "flapi.yaml", "--validate-config"],
+            capture_output=True,
+            text=True,
+            cwd=temp_config_dir
+        )
+
+        assert result.returncode == 0, f"Validation failed: {result.stderr}"
+
+
+class TestVFSHttpServer:
+    """Tests for loading config and templates from HTTP server."""
+
+    @pytest.fixture
+    def http_server(self):
+        """Start a temporary HTTP server serving test files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create sqls subdirectory
+            sqls_dir = os.path.join(tmpdir, "sqls")
+            os.makedirs(sqls_dir)
+
+            # Find a free port
+            port = find_free_port()
+
+            # Create handler class with the directory
+            handler = lambda *args, **kwargs: SimpleHTTPHandler(
+                *args, directory=tmpdir, **kwargs
+            )
+
+            # Start server
+            server = http.server.HTTPServer(('127.0.0.1', port), handler)
+            thread = threading.Thread(target=server.serve_forever)
+            thread.daemon = True
+            thread.start()
+
+            yield {
+                "port": port,
+                "url": f"http://127.0.0.1:{port}",
+                "dir": tmpdir,
+                "sqls_dir": sqls_dir,
+                "server": server
+            }
+
+            server.shutdown()
+
+    def test_http_endpoint_yaml_accessible(self, http_server):
+        """Test that endpoint YAML can be served via HTTP."""
+        sqls_dir = http_server["sqls_dir"]
+
+        # Create endpoint YAML
+        endpoint = {
+            "url-path": "/http-test",
+            "method": "GET",
+            "template-source": "http_test.sql",
+            "connection": ["test"]
+        }
+
+        endpoint_path = os.path.join(sqls_dir, "http_test.yaml")
+        with open(endpoint_path, "w") as f:
+            yaml.dump(endpoint, f)
+
+        # Verify file is accessible via HTTP
+        import urllib.request
+        url = f"{http_server['url']}/sqls/http_test.yaml"
+
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode('utf-8')
+                loaded = yaml.safe_load(content)
+                assert loaded["url-path"] == "/http-test"
+        except Exception as e:
+            pytest.fail(f"Failed to fetch endpoint YAML via HTTP: {e}")
+
+    def test_http_sql_template_accessible(self, http_server):
+        """Test that SQL template can be served via HTTP."""
+        sqls_dir = http_server["sqls_dir"]
+
+        # Create SQL template
+        template = "SELECT 42 as answer"
+        template_path = os.path.join(sqls_dir, "http_test.sql")
+        with open(template_path, "w") as f:
+            f.write(template)
+
+        # Verify file is accessible via HTTP
+        import urllib.request
+        url = f"{http_server['url']}/sqls/http_test.sql"
+
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode('utf-8')
+                assert content == template
+        except Exception as e:
+            pytest.fail(f"Failed to fetch SQL template via HTTP: {e}")
+
+
+class TestVFSErrorHandling:
+    """Tests for error handling with remote file access."""
+
+    @pytest.fixture
+    def temp_config_dir(self):
+        """Create a temporary directory with basic config structure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sqls_dir = os.path.join(tmpdir, "sqls")
+            os.makedirs(sqls_dir)
+            yield tmpdir
+
+    def test_unreachable_template_path_error(self, temp_config_dir):
+        """Test that unreachable remote template path gives clear error."""
+        flapi_binary = get_flapi_binary()
+        sqls_dir = os.path.join(temp_config_dir, "sqls")
+
+        # Create config with local path
+        config = {
+            "project-name": "vfs-error-test",
+            "project-description": "VFS error handling test",
+            "http-port": 8080,
+            "template": {"path": "./sqls"},
+            "connections": {
+                "test": {"properties": {"path": "./data.parquet"}}
+            }
+        }
+
+        # Endpoint pointing to unreachable HTTP URL
+        endpoint = {
+            "url-path": "/unreachable",
+            "method": "GET",
+            "template-source": "https://this-url-does-not-exist-12345.invalid/template.sql",
+            "connection": ["test"]
+        }
+
+        config_path = os.path.join(temp_config_dir, "flapi.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+
+        endpoint_path = os.path.join(sqls_dir, "unreachable.yaml")
+        with open(endpoint_path, "w") as f:
+            yaml.dump(endpoint, f)
+
+        result = subprocess.run(
+            [str(flapi_binary), "-c", config_path, "--validate-config"],
+            capture_output=True,
+            text=True,
+            cwd=temp_config_dir,
+            timeout=30
+        )
+
+        # We expect validation to fail or warn about unreachable template
+        # The exact behavior depends on whether templates are validated at config time
+        # For now, we just verify the command completes (doesn't hang)
+        assert result.returncode is not None, "Command should complete"
+
+
+class TestVFSPathSecurity:
+    """Tests for path validation security features."""
+
+    def test_path_traversal_warns_file_not_found(self):
+        """Test that path traversal attempts result in file-not-found warning.
+
+        Note: The PathValidator class provides traversal detection at the library level.
+        Full integration into the config validation pipeline is a follow-up task.
+        This test verifies the current behavior where traversal paths are reported
+        as missing files (validation passes with warning, no sensitive data read).
+        """
+        flapi_binary = get_flapi_binary()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sqls_dir = os.path.join(tmpdir, "sqls")
+            os.makedirs(sqls_dir)
+
+            config = {
+                "project-name": "security-test",
+                "project-description": "VFS security test",
+                "http-port": 8080,
+                "template": {"path": "./sqls"},
+                "connections": {
+                    "test": {"properties": {"path": "./data.parquet"}}
+                }
+            }
+
+            # Endpoint with path traversal in template source
+            endpoint = {
+                "url-path": "/traversal",
+                "method": "GET",
+                "template-source": "../../../etc/passwd",
+                "connection": ["test"]
+            }
+
+            config_path = os.path.join(tmpdir, "flapi.yaml")
+            with open(config_path, "w") as f:
+                yaml.dump(config, f)
+
+            endpoint_path = os.path.join(sqls_dir, "traversal.yaml")
+            with open(endpoint_path, "w") as f:
+                yaml.dump(endpoint, f)
+
+            result = subprocess.run(
+                [str(flapi_binary), "-c", config_path, "--validate-config"],
+                capture_output=True,
+                text=True,
+                cwd=tmpdir,
+                timeout=30
+            )
+
+            # Current behavior: validation passes with warning about file not found
+            # The traversal path doesn't actually read /etc/passwd
+            # Verify that:
+            # 1. The warning mentions the file doesn't exist
+            # 2. No actual sensitive data (like "root:") appears in output
+            assert "does not exist" in result.stdout.lower(), "Should warn about missing file"
+            assert "root:" not in result.stdout, "Should not read /etc/passwd content"
+
+
+class TestVFSMixedPaths:
+    """Tests for mixed local and remote path configurations."""
+
+    @pytest.fixture
+    def mixed_config_dir(self):
+        """Create a directory with mixed local/remote config setup."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sqls_dir = os.path.join(tmpdir, "sqls")
+            os.makedirs(sqls_dir)
+
+            # Create some local files
+            local_template = os.path.join(sqls_dir, "local.sql")
+            with open(local_template, "w") as f:
+                f.write("SELECT 'local' as source")
+
+            local_endpoint = os.path.join(sqls_dir, "local.yaml")
+            with open(local_endpoint, "w") as f:
+                yaml.dump({
+                    "url-path": "/local",
+                    "method": "GET",
+                    "template-source": "local.sql",
+                    "connection": ["test"]
+                }, f)
+
+            yield tmpdir
+
+    def test_local_paths_work_with_vfs_enabled(self, mixed_config_dir):
+        """Test that local paths continue to work with VFS abstraction."""
+        flapi_binary = get_flapi_binary()
+
+        config = {
+            "project-name": "mixed-test",
+            "project-description": "VFS mixed paths test",
+            "http-port": 8080,
+            "template": {"path": "./sqls"},
+            "connections": {
+                "test": {"properties": {"path": "./data.parquet"}}
+            }
+        }
+
+        config_path = os.path.join(mixed_config_dir, "flapi.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+
+        result = subprocess.run(
+            [str(flapi_binary), "-c", config_path, "--validate-config"],
+            capture_output=True,
+            text=True,
+            cwd=mixed_config_dir
+        )
+
+        assert result.returncode == 0, f"Local paths should work: {result.stderr}"
+
+
+@pytest.mark.skip(reason="Requires LocalStack for S3 testing")
+class TestVFSS3Integration:
+    """Tests for S3 path support (requires LocalStack)."""
+
+    def test_s3_config_loading(self):
+        """Test loading config from S3 bucket."""
+        # This test requires LocalStack to be running
+        # and configured with appropriate test buckets
+        pass
+
+    def test_s3_template_loading(self):
+        """Test loading SQL templates from S3."""
+        pass
+
+    def test_s3_hot_reload(self):
+        """Test hot-reload when S3 files change."""
+        pass


### PR DESCRIPTION
## Summary

- Add `IFileProvider` interface abstracting file operations (ReadFile, FileExists, ListFiles, IsRemotePath)
- Implement `LocalFileProvider` using std::filesystem for local file operations
- Add `PathSchemeUtils` for URI scheme detection (s3://, gs://, az://, azure://, http://, https://, file://)
- Add `FileProviderFactory` for creating appropriate providers based on path scheme
- Include comprehensive unit tests (17 test cases, 108 assertions)
- Add design document outlining the full VFS feature roadmap

## Test plan

- [x] All 17 VFS adapter unit tests pass (108 assertions)
- [x] Full test suite passes (310/312 - 2 pre-existing macOS symlink failures unrelated to this PR)
- [x] Debug build compiles successfully
- [x] Manual verification: Existing functionality unaffected

## Implementation Notes

This PR implements the first task (`flapi-272`) of the VFS epic (`flapi-gwy`). The abstraction layer is designed to:

1. **Maintain backward compatibility** - LocalFileProvider wraps existing std::filesystem operations
2. **Enable future cloud storage** - Interface designed for DuckDBVFSProvider (next task)
3. **Support URI-style paths** - Scheme detection ready for s3://, gs://, az://, https://

### Next steps (future PRs):
- `flapi-6f0`: Implement DuckDBVFSProvider with httpfs extension
- `flapi-pc9`: Integrate VFSAdapter into ConfigLoader
- `flapi-snt`: Integrate VFSAdapter into SQLTemplateProcessor

Closes #10 (partial - first phase of multi-phase implementation)