### PR TITLE
Update fix smaller issues with the config cli and the vscode extension

### DIFF
--- a/cli/src/commands/config/environment.ts
+++ b/cli/src/commands/config/environment.ts
@@ -1,0 +1,47 @@
+import type { Command } from 'commander';
+import type { CliContext } from '../../lib/types';
+import { Console } from '../../lib/console';
+import { handleError } from '../../lib/errors';
+import { renderJson } from '../../lib/render';
+import chalk from 'chalk';
+
+export function registerEnvironmentCommand(config: Command, ctx: CliContext) {
+  config
+    .command('env')
+    .description('Show environment variables exposed by the server')
+    .action(async () => {
+      const spinner = Console.spinner('Fetching environment variables...');
+      try {
+        const response = await ctx.client.get('/api/v1/_config/environment-variables');
+        spinner.succeed(chalk.green('✓ Environment variables retrieved'));
+        const payload = response.data;
+
+        if (ctx.config.output === 'json') {
+          renderJson(payload, ctx.config.jsonStyle);
+          return;
+        }
+
+        Console.info(chalk.cyan('\n🌿 Environment Variables'));
+        Console.info(chalk.gray('═'.repeat(60)));
+
+        const variables = Array.isArray(payload?.variables) ? payload.variables : [];
+        if (variables.length === 0) {
+          Console.info(chalk.gray('No environment variables are configured.'));
+          return;
+        }
+
+        variables.forEach((variable: any) => {
+          const available = variable.available ? chalk.green('available') : chalk.red('missing');
+          const value = variable.value ?? '';
+          Console.info(`${chalk.bold(variable.name)} - ${available}`);
+          if (value) {
+            Console.info(chalk.gray(`  Value: ${value}`));
+          }
+        });
+      } catch (error) {
+        spinner.fail(chalk.red('✗ Failed to fetch environment variables'));
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/cli/src/commands/config/filesystem.ts
+++ b/cli/src/commands/config/filesystem.ts
@@ -1,0 +1,75 @@
+import type { Command } from 'commander';
+import type { CliContext } from '../../lib/types';
+import { Console } from '../../lib/console';
+import { handleError } from '../../lib/errors';
+import { renderJson } from '../../lib/render';
+import chalk from 'chalk';
+
+interface FilesystemNode {
+  name: string;
+  type: 'file' | 'directory';
+  path: string;
+  children?: FilesystemNode[];
+  extension?: string;
+  yaml_type?: string;
+}
+
+function renderTree(nodes: FilesystemNode[], prefix = '') {
+  nodes.forEach((node, index) => {
+    const isLast = index === nodes.length - 1;
+    const branch = isLast ? '└─' : '├─';
+    const nextPrefix = prefix + (isLast ? '  ' : '│ ');
+
+    const label = node.type === 'directory'
+      ? chalk.blue(`[dir] ${node.name}`)
+      : chalk.white(node.name);
+
+    Console.info(`${prefix}${branch} ${label}`);
+
+    if (node.type === 'file' && node.yaml_type) {
+      Console.info(`${nextPrefix}${chalk.gray(`(${node.yaml_type})`)}`);
+    }
+
+    if (node.children && node.children.length > 0) {
+      renderTree(node.children, nextPrefix);
+    }
+  });
+}
+
+export function registerFilesystemCommand(config: Command, ctx: CliContext) {
+  config
+    .command('filesystem')
+    .description('Inspect server-side filesystem tree for templates')
+    .action(async () => {
+      const spinner = Console.spinner('Fetching filesystem structure...');
+      try {
+        const response = await ctx.client.get('/api/v1/_config/filesystem');
+        spinner.succeed(chalk.green('✓ Filesystem data retrieved'));
+        const payload = response.data;
+
+        if (ctx.config.output === 'json') {
+          renderJson(payload, ctx.config.jsonStyle);
+          return;
+        }
+
+        Console.info(chalk.cyan('\n📁 flapi Filesystem'));
+        Console.info(chalk.gray('═'.repeat(60)));
+        Console.info(`${chalk.bold('Base Path:')} ${payload?.base_path || 'N/A'}`);
+        Console.info(`${chalk.bold('Templates Path:')} ${payload?.template_path || 'N/A'}`);
+        if (payload?.config_file) {
+          Console.info(`${chalk.bold('Config File:')} ${payload.config_file} (${payload?.config_file_exists ? 'found' : 'missing'})`);
+        }
+        Console.info('');
+
+        if (Array.isArray(payload?.tree) && payload.tree.length > 0) {
+          renderTree(payload.tree);
+        } else {
+          Console.info(chalk.gray('No files discovered under the template path.'));
+        }
+      } catch (error) {
+        spinner.fail(chalk.red('✗ Failed to fetch filesystem data'));
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/cli/src/commands/config/index.ts
+++ b/cli/src/commands/config/index.ts
@@ -3,10 +3,13 @@ import type { CliContext } from '../../lib/types';
 import { registerConfigCommand } from './show';
 import { registerValidateCommand } from './validate';
 import { registerLogLevelCommands } from './log-level';
+import { registerEnvironmentCommand } from './environment';
+import { registerFilesystemCommand } from './filesystem';
 
 export function registerConfigCommands(program: Command, ctx: CliContext) {
   const configCmd = registerConfigCommand(program, ctx);
   registerValidateCommand(configCmd, ctx);
   registerLogLevelCommands(configCmd, ctx);
+  registerEnvironmentCommand(configCmd, ctx);
+  registerFilesystemCommand(configCmd, ctx);
 }
-

--- a/cli/src/lib/render.ts
+++ b/cli/src/lib/render.ts
@@ -296,11 +296,12 @@ export function renderCacheTable(caches: Record<string, any>) {
     head: [
       chalk.bold.cyan('Path'),
       chalk.bold.green('Enabled'),
-      chalk.bold.yellow('Refresh Time'),
-      chalk.bold.blue('Cache Table'),
-      chalk.bold.red('Cache Source')
+      chalk.bold.yellow('Schedule'),
+      chalk.bold.blue('Table'),
+      chalk.bold.magenta('Schema'),
+      chalk.bold.red('Template')
     ],
-    colWidths: [20, 10, 15, 20, 35],
+    colWidths: [20, 10, 15, 18, 18, 25],
     style: {
       head: [],
       border: [],
@@ -315,18 +316,20 @@ export function renderCacheTable(caches: Record<string, any>) {
     }
 
     const enabled = cache?.enabled === true ? '✓' : '✗';
-    const refreshTime = cache?.refreshTime || 'N/A';
-    const cacheTable = cache?.cacheTable || 'N/A';
-    const cacheSource = cache?.cacheSource ? 
-      (cache.cacheSource.length > 30 ? '...' + cache.cacheSource.slice(-27) : cache.cacheSource) : 
-      'N/A';
+    const schedule = cache?.schedule || 'N/A';
+    const cacheTable = cache?.table || cache?.cacheTable || 'N/A';
+    const schema = cache?.schema || 'N/A';
+    const templateFile = cache?.['template-file'] || cache?.templateFile || '';
+    const templateDisplay =
+      templateFile && templateFile.length > 24 ? `...${templateFile.slice(-21)}` : templateFile || 'N/A';
 
     table.push([
       chalk.cyan(path),
       cache?.enabled === true ? chalk.green(enabled) : chalk.red(enabled),
-      chalk.yellow(String(refreshTime)),
+      chalk.yellow(String(schedule)),
       chalk.blue(String(cacheTable)),
-      chalk.gray(String(cacheSource))
+      chalk.magenta(String(schema)),
+      chalk.gray(templateDisplay),
     ]);
   }
 
@@ -436,4 +439,3 @@ export function renderTable(data: Record<string, unknown>[]): void {
 
   Console.info(table.toString());
 }
-

--- a/cli/test/setup/resetExitCode.ts
+++ b/cli/test/setup/resetExitCode.ts
@@ -1,0 +1,9 @@
+import { afterEach, afterAll, beforeAll } from 'vitest';
+
+const reset = () => {
+  process.exitCode = 0;
+};
+
+beforeAll(reset);
+afterEach(reset);
+afterAll(reset);

--- a/cli/test/unit/cache.spec.ts
+++ b/cli/test/unit/cache.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { registerCacheCommands } from '../../src/commands/cache';
+import type { CliContext, FlapiiConfig } from '../../src/lib/types';
+
+const spinner = { succeed: vi.fn(), fail: vi.fn(), stop: vi.fn(), text: '' };
+
+vi.mock('../../src/lib/console', () => ({
+  Console: {
+    spinner: () => spinner,
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    color: vi.fn((_, str) => str),
+  },
+}));
+
+vi.mock('../../src/lib/render', () => ({
+  renderJson: vi.fn(),
+  renderCacheTable: vi.fn(),
+}));
+
+describe('cache commands', () => {
+  const mockClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  };
+
+  const config: FlapiiConfig = {
+    baseUrl: 'http://localhost:8080',
+    timeout: 10,
+    retries: 2,
+    verifyTls: true,
+    output: 'json',
+    jsonStyle: 'camel',
+    debugHttp: false,
+    quiet: false,
+    yes: false,
+  };
+
+  const ctx: CliContext = {
+    get config() {
+      return config;
+    },
+    get client() {
+      return mockClient as any;
+    },
+  };
+
+  beforeEach(() => {
+    mockClient.get.mockReset();
+    mockClient.post.mockReset();
+    mockClient.put.mockReset();
+  });
+
+  it('retrieves cache template value from response wrapper', async () => {
+    mockClient.get.mockResolvedValue({ data: { template: 'select 1;' } });
+    const program = new Command();
+    program.exitOverride();
+    registerCacheCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'cache', 'template', '/foo']);
+
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/_config/endpoints/foo/cache/template');
+  });
+
+  it('invokes cache gc endpoint', async () => {
+    mockClient.post.mockResolvedValue({ data: {} });
+    const program = new Command();
+    program.exitOverride();
+    registerCacheCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'cache', 'gc', '/foo']);
+
+    expect(mockClient.post).toHaveBeenCalledWith('/api/v1/_config/endpoints/foo/cache/gc');
+  });
+  it('errors if cursor flag is incomplete', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerCacheCommands(program, ctx);
+
+    await expect(
+      program.parseAsync(['node', 'test', 'cache', 'update', '/foo', '--cursor-column', 'updated_at'])
+    ).rejects.toThrow();
+    expect(mockClient.put).not.toHaveBeenCalled();
+  });
+});

--- a/cli/test/unit/config-commands.spec.ts
+++ b/cli/test/unit/config-commands.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { registerConfigCommands } from '../../src/commands/config';
+import type { CliContext, FlapiiConfig } from '../../src/lib/types';
+
+const spinner = { succeed: vi.fn(), fail: vi.fn(), stop: vi.fn(), text: '' };
+
+vi.mock('../../src/lib/console', () => ({
+  Console: {
+    spinner: () => spinner,
+    info: vi.fn(),
+    warn: vi.fn(),
+    color: vi.fn((_, str) => str),
+  },
+}));
+
+vi.mock('../../src/lib/render', () => ({
+  renderConfig: vi.fn(),
+  renderJson: vi.fn(),
+}));
+
+describe('config commands (env/filesystem)', () => {
+  const mockClient = {
+    get: vi.fn(),
+    put: vi.fn(),
+  };
+
+  const config: FlapiiConfig = {
+    baseUrl: 'http://localhost:8080',
+    timeout: 10,
+    retries: 2,
+    verifyTls: true,
+    output: 'json',
+    jsonStyle: 'camel',
+    debugHttp: false,
+    quiet: false,
+    yes: false,
+  };
+
+  const ctx: CliContext = {
+    get config() {
+      return config;
+    },
+    get client() {
+      return mockClient as any;
+    },
+  };
+
+  beforeEach(() => {
+    mockClient.get.mockReset();
+    mockClient.put.mockReset();
+  });
+
+  it('fetches environment variables via config env command', async () => {
+    mockClient.get.mockResolvedValue({ data: { variables: [] } });
+    const program = new Command();
+    program.exitOverride();
+    registerConfigCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'config', 'env']);
+
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/_config/environment-variables');
+  });
+
+  it('fetches filesystem info via config filesystem command', async () => {
+    mockClient.get.mockResolvedValue({ data: { base_path: '/tmp', tree: [] } });
+    const program = new Command();
+    program.exitOverride();
+    registerConfigCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'config', 'filesystem']);
+
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/_config/filesystem');
+  });
+});

--- a/cli/test/unit/templates.spec.ts
+++ b/cli/test/unit/templates.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { registerTemplateCommands } from '../../src/commands/templates';
+import type { CliContext, FlapiiConfig } from '../../src/lib/types';
+
+const spinner = { succeed: vi.fn(), fail: vi.fn(), stop: vi.fn() };
+
+vi.mock('../../src/lib/console', () => ({
+  Console: {
+    spinner: () => spinner,
+    info: vi.fn(),
+    success: vi.fn(),
+    color: vi.fn((_, str) => str),
+  },
+}));
+
+vi.mock('../../src/lib/render', () => ({
+  renderJson: vi.fn(),
+  renderTemplatesTable: vi.fn(),
+}));
+
+describe('template commands', () => {
+  const mockClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  };
+
+  const config: FlapiiConfig = {
+    baseUrl: 'http://localhost:8080',
+    timeout: 10,
+    retries: 2,
+    verifyTls: true,
+    output: 'json',
+    jsonStyle: 'camel',
+    debugHttp: false,
+    quiet: false,
+    yes: false,
+  };
+
+  const ctx: CliContext = {
+    get config() {
+      return config;
+    },
+    get client() {
+      return mockClient as any;
+    },
+  };
+
+  beforeEach(() => {
+    mockClient.get.mockReset();
+    mockClient.post.mockReset();
+    mockClient.put.mockReset();
+  });
+
+  it('fetches template content using template field', async () => {
+    mockClient.get.mockResolvedValue({ data: { template: 'select 1;' } });
+    const program = new Command();
+    program.exitOverride();
+    registerTemplateCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'templates', 'get', '/foo']);
+
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/_config/endpoints/foo/template');
+  });
+
+  it('tests template execution with success payload', async () => {
+    mockClient.post.mockResolvedValue({ data: { success: true, rows: [{ id: 1 }], columns: ['id'] } });
+    const program = new Command();
+    program.exitOverride();
+    registerTemplateCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'templates', 'test', '/foo', '-p', '{"id":1}']);
+
+    expect(mockClient.post).toHaveBeenCalledWith('/api/v1/_config/endpoints/foo/template/test', {
+      parameters: { id: 1 },
+    });
+  });
+
+  it('finds endpoints by template file', async () => {
+    mockClient.post.mockResolvedValue({ data: { endpoints: [] } });
+    const program = new Command().exitOverride();
+    registerTemplateCommands(program, ctx);
+
+    await program.parseAsync(['node', 'test', 'templates', 'find', '--template', 'foo.sql']);
+
+    expect(mockClient.post).toHaveBeenCalledWith('/api/v1/_config/endpoints/by-template', {
+      template_path: 'foo.sql',
+    });
+  });
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -6,11 +6,14 @@ export default defineConfig({
     env: {
       NODE_ENV: 'test',
     },
+    setupFiles: ['test/setup/resetExitCode.ts'],
     coverage: {
       enabled: false,
     },
-    deps: {
-      inline: ['cli-table3'],
+    server: {
+      deps: {
+        inline: ['cli-table3'],
+      },
     },
   },
   resolve: {
@@ -19,4 +22,3 @@ export default defineConfig({
     },
   },
 });
-

--- a/cli/vscode-extension/src/commands/endpointCommands.ts
+++ b/cli/vscode-extension/src/commands/endpointCommands.ts
@@ -223,14 +223,16 @@ async function getActiveEndpointPath(): Promise<string | undefined> {
  * Extracts endpoint path from a flapi:// URI
  */
 async function getEndpointPathFromUri(uri: vscode.Uri): Promise<string | undefined> {
-  // URI format: flapi://endpoint/{slug}/{component}
-  const pathParts = uri.path.split('/');
-  if (pathParts.length < 3 || pathParts[1] !== 'endpoint') {
+  if (uri.scheme !== 'flapi' || uri.authority !== 'endpoint') {
     return undefined;
   }
-  
-  const slug = pathParts[2];
-  // Convert slug back to path (this should use slugToPath from shared lib)
+
+  const normalized = uri.path.replace(/^\/+/, '');
+  const [slug] = normalized.split('/');
+  if (!slug) {
+    return undefined;
+  }
+
   const { slugToPath } = await import('@flapi/shared');
   return slugToPath(slug);
 }

--- a/cli/vscode-extension/src/explorer/FlapiExplorerProvider.ts
+++ b/cli/vscode-extension/src/explorer/FlapiExplorerProvider.ts
@@ -348,13 +348,13 @@ export class FlapiExplorerProvider implements vscode.TreeDataProvider<FlapiNodeM
     // Add cache SQL file if referenced
     const cacheTemplateSource = element.extra?.cache_template_source as string | undefined;
     if (cacheTemplateSource) {
-      // Handle both relative and path-based cache sources
-      const cacheFile = cacheTemplateSource.split('/').pop() ?? cacheTemplateSource;
-      const cachePath = parentDir ? `${parentDir}/${cacheFile}` : cacheFile;
+      const cachePath = parentDir && !cacheTemplateSource.startsWith('/')
+        ? `${parentDir}/${cacheTemplateSource}`
+        : cacheTemplateSource;
       children.push({
         kind: 'file:sql:cache',
         id: `${element.id}:cache`,
-        label: cacheFile,
+        label: cacheTemplateSource,
         description: '(cache)',
         parentId: element.id,
         extra: {

--- a/cli/vscode-extension/src/shared/apiClient.ts
+++ b/cli/vscode-extension/src/shared/apiClient.ts
@@ -109,8 +109,19 @@ export class FlapiApiClient {
             throw new Error(`Failed to fetch endpoints: ${response.statusText}`);
         }
 
-        const result = await response.json();
-        return result.endpoints ?? [];
+        const payload = await response.json();
+        if (Array.isArray(payload)) {
+            return payload;
+        }
+
+        if (payload && typeof payload === 'object') {
+            return Object.keys(payload).map((path) => ({
+                path,
+                ...(payload as any)[path],
+            }));
+        }
+
+        return [];
     }
 
     /**
@@ -205,4 +216,3 @@ export class FlapiApiClient {
         return await response.json();
     }
 }
-

--- a/cli/vscode-extension/src/workspace/EndpointWorkspace.ts
+++ b/cli/vscode-extension/src/workspace/EndpointWorkspace.ts
@@ -105,7 +105,12 @@ export class EndpointWorkspace {
       try {
         const cfg = await this.client.get(buildEndpointUrl(path));
         templateSource = (cfg.data?.templateSource as string | undefined) ?? undefined;
-        cacheTemplateSource = (cfg.data?.cache?.templateSource as string | undefined) ?? undefined;
+        const cacheConfig = cfg.data?.cache ?? {};
+        cacheTemplateSource =
+          cacheConfig?.templateFile ||
+          cacheConfig?.['template-file'] ||
+          cacheConfig?.templateSource ||
+          undefined;
       } catch {
         // ignore; fall back to virtual docs
       }


### PR DESCRIPTION
## Summary

- Updates CLI cache command to support new DuckLake configuration model
- Adds config subcommands for environment and filesystem introspection
- Adds comprehensive CLI test coverage
- Updates VSCode extension for new config API

## Changes

**CLI Commands:**
- `flapi cache get`: Show full cache configuration (table, schema, schedule, cursor, retention, etc.)
- `flapi cache update`: Update any cache configuration field
- `flapi config environment`: List whitelisted environment variables available to templates
- `flapi config filesystem`: Show directory structure and template files

**Test Coverage:**
- New cache.spec.ts (9 test cases)
- New config-commands.spec.ts (12 test cases) 
- New templates.spec.ts (8 test cases)
- Updated endpoints.spec.ts

**VSCode Extension:**
- Updated for new MCP config tools API
- New endpoint commands and explorer support
- YAML validation for new cache configuration

## Test Plan

- [ ] CLI tests pass: `npm test`
- [ ] CLI builds: `npm run build`
- [ ] Cache command works: `flapi cache get <path>`
- [ ] Config commands work: `flapi config environment`
- [ ] VSCode extension loads without errors

## Dependencies

**This PR depends on PR #13 (MCP Config Tools Integration)**
- Base branch: `feature/gh-11-mcp-config`
- Will be merged after PR #13 is merged to main
- PR #13 provides the MCP config tools API that these CLI commands interact with