### PR TITLE
feat(security): Wave 0 — startup auditor + honest SQL-injection docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,8 +248,10 @@ Templates are **Mustache files** that generate SQL from request parameters.
 - `env.*` - Whitelisted environment variables
 
 **Key Rule: Triple vs. Double Braces**
-- **Triple braces `{{{ }}}`** for strings: Auto-escapes quotes, prevents SQL injection
-- **Double braces `{{ }}`** for numbers/identifiers: No quotes, safe for numeric types
+- **Triple braces `{{{ }}}`** for strings: Renders the raw value (no HTML entity escaping). Use inside single-quoted SQL string literals.
+- **Double braces `{{ }}`** for numbers/identifiers: HTML-escapes the value (turns `<` into `&lt;` etc.), which is harmless but not SQL-aware — use only where the value is a number or known-safe identifier.
+
+> **Security note:** Neither form performs SQL-specific escaping. Mustache does not understand SQL string literals, quote-doubling, or comment syntax. Defense against injection comes from the `RequestValidator` (typed fields, regex/range/enum checks) and disciplined template authoring (quote string params, parameterise numerics). When in doubt, add a stricter validator rather than relying on rendering.
 
 **Example Template:**
 ```sql

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ add_library(flapi-lib STATIC
     src/request_validator.cpp
     src/rate_limit_middleware.cpp
     src/route_translator.cpp
+    src/security_auditor.cpp
     src/sql_template_processor.cpp
     src/sql_utils.cpp
     src/mcp_server.cpp

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -1362,13 +1362,15 @@ WHERE id = {{ params.id }}
 LIMIT {{ params.limit }}
 ```
 
-**Triple Braces `{{{ }}}`** - For string values (escapes quotes, prevents SQL injection):
+**Triple Braces `{{{ }}}`** - For string values, renders the raw value with no HTML entity escaping. Use this form inside single-quoted SQL string literals:
 
 ```sql
 SELECT * FROM table
 WHERE name = '{{{ params.name }}}'
 AND status = '{{{ params.status }}}'
 ```
+
+> **Security note:** Neither double nor triple braces perform SQL-specific escaping. Mustache does not understand SQL string literals, quote-doubling, or comment syntax. Defense against SQL injection comes from the `RequestValidator` (typed fields, regex/range/enum checks) plus disciplined template authoring — not from the brace form alone. Pair every user-supplied string field with an appropriately strict validator.
 
 ### 9.2 Available Contexts
 
@@ -1416,12 +1418,14 @@ WHERE 1=1
 **2. Always Use Triple Braces for Strings:**
 
 ```sql
--- CORRECT: Prevents SQL injection
+-- CORRECT: renders the raw string inside the quoted literal
 WHERE name = '{{{ params.name }}}'
 
--- INCORRECT: Vulnerable to injection
+-- INCORRECT: HTML-entity escaping mangles legitimate characters (e.g., `'` → `&#39;`)
 WHERE name = '{{ params.name }}'
 ```
+
+Note: the triple-brace rule keeps the rendered SQL syntactically correct. It does **not** by itself prevent SQL injection — that protection comes from the `RequestValidator` for the corresponding request field.
 
 **3. Provide Default Values:**
 

--- a/src/include/security_auditor.hpp
+++ b/src/include/security_auditor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace flapi {
+
+class ConfigManager;
+
+struct SecurityWarning {
+    std::string code;
+    std::string message;
+    std::string location;
+};
+
+class SecurityAuditor {
+public:
+    std::vector<SecurityWarning> audit(const ConfigManager& config) const;
+
+    static std::string classifyPassword(const std::string& password);
+};
+
+} // namespace flapi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "rate_limit_middleware.hpp"
 #include "config_token_utils.hpp"
 #include "credential_manager.hpp"
+#include "security_auditor.hpp"
 #include "vfs_health_checker.hpp"
 
 using namespace flapi;
@@ -88,6 +89,23 @@ void printValidationWarnings(const std::string& endpoint_name, const std::vector
         std::cout << "  WARNING: " << warning << std::endl;
         warnings_count++;
     }
+}
+
+void printSecurityWarnings(const std::vector<SecurityWarning>& warnings) {
+    if (warnings.empty()) {
+        return;
+    }
+    std::cerr << "\n" << std::string(60, '=') << std::endl;
+    std::cerr << "SECURITY WARNINGS (" << warnings.size() << ")" << std::endl;
+    std::cerr << std::string(60, '=') << std::endl;
+    for (const auto& w : warnings) {
+        std::cerr << "[" << w.code << "] " << w.message;
+        if (!w.location.empty()) {
+            std::cerr << " (at: " << w.location << ")";
+        }
+        std::cerr << std::endl;
+    }
+    std::cerr << std::endl;
 }
 
 void printValidationSummary(bool all_valid, int errors_count, int warnings_count) {
@@ -315,6 +333,13 @@ int main(int argc, char* argv[])
     set_log_level(log_level);
 
     auto config_manager = initializeConfig(config_file);
+
+    // Surface configuration-level security warnings (plaintext passwords, MCP without auth, etc.)
+    // Runs in both --validate-config mode and normal server start; never aborts startup.
+    {
+        SecurityAuditor auditor;
+        printSecurityWarnings(auditor.audit(*config_manager));
+    }
 
     // If validate-config flag is set, validate and exit
     if (validate_config) {

--- a/src/security_auditor.cpp
+++ b/src/security_auditor.cpp
@@ -1,0 +1,98 @@
+#include "security_auditor.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#include "config_manager.hpp"
+
+namespace flapi {
+
+namespace {
+
+bool isBcryptPrefix(const std::string& password) {
+    if (password.size() < 4) {
+        return false;
+    }
+    if (password[0] != '$' || password[1] != '2' || password[3] != '$') {
+        return false;
+    }
+    const char variant = password[2];
+    return variant == 'a' || variant == 'b' || variant == 'y';
+}
+
+bool isMd5HexDigest(const std::string& password) {
+    if (password.size() != 32) {
+        return false;
+    }
+    return std::all_of(password.begin(), password.end(), [](char c) {
+        return std::isxdigit(static_cast<unsigned char>(c)) != 0;
+    });
+}
+
+void scanUsers(const std::vector<AuthUser>& users,
+               const std::string& location,
+               std::vector<SecurityWarning>& out) {
+    for (const auto& user : users) {
+        const std::string code = SecurityAuditor::classifyPassword(user.password);
+        if (code == "AUTH_PLAINTEXT_PASSWORD") {
+            out.push_back({
+                code,
+                "User '" + user.username + "' has a plaintext password. "
+                "Use bcrypt instead (see flapii auth hash, when available).",
+                location
+            });
+        } else if (code == "AUTH_MD5_PASSWORD") {
+            out.push_back({
+                code,
+                "User '" + user.username + "' has an MD5-hashed password. "
+                "MD5 is cryptographically broken; migrate to bcrypt.",
+                location
+            });
+        }
+    }
+}
+
+} // namespace
+
+std::string SecurityAuditor::classifyPassword(const std::string& password) {
+    if (password.empty()) {
+        return {};
+    }
+    if (isBcryptPrefix(password)) {
+        return {};
+    }
+    if (isMd5HexDigest(password)) {
+        return "AUTH_MD5_PASSWORD";
+    }
+    return "AUTH_PLAINTEXT_PASSWORD";
+}
+
+std::vector<SecurityWarning> SecurityAuditor::audit(const ConfigManager& config) const {
+    std::vector<SecurityWarning> warnings;
+
+    for (const auto& endpoint : config.getEndpoints()) {
+        scanUsers(endpoint.auth.users, "endpoint " + endpoint.getIdentifier(), warnings);
+    }
+
+    const auto& mcp = config.getMCPConfig();
+    scanUsers(mcp.auth.users, "mcp.auth", warnings);
+
+    if (mcp.enabled && !mcp.auth.enabled) {
+        const bool any_mcp_tool = std::any_of(
+            config.getEndpoints().begin(), config.getEndpoints().end(),
+            [](const EndpointConfig& e) { return e.isMCPTool(); });
+        if (any_mcp_tool) {
+            warnings.push_back({
+                "MCP_UNAUTHENTICATED_TOOLS",
+                "MCP tools are exposed without authentication (mcp.auth.enabled is false). "
+                "Anyone reaching the server can invoke any MCP tool. "
+                "Enable mcp.auth.enabled and configure users or JWT before exposing this server.",
+                "mcp"
+            });
+        }
+    }
+
+    return warnings;
+}
+
+} // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(flapi_tests
     rate_limit_middleware_test.cpp
     request_handler_test.cpp
     request_validator_test.cpp
+    security_auditor_test.cpp
     sql_template_processor_test.cpp
     sql_utils_test.cpp
     test_duckdb_raii.cpp

--- a/test/cpp/security_auditor_test.cpp
+++ b/test/cpp/security_auditor_test.cpp
@@ -1,0 +1,301 @@
+#include <catch2/catch_test_macros.hpp>
+#include <algorithm>
+
+#include "config_manager.hpp"
+#include "security_auditor.hpp"
+#include "test_utils.hpp"
+
+namespace flapi {
+namespace test {
+
+namespace {
+
+bool hasWarning(const std::vector<SecurityWarning>& warnings, const std::string& code) {
+    return std::any_of(warnings.begin(), warnings.end(),
+                       [&](const SecurityWarning& w) { return w.code == code; });
+}
+
+} // namespace
+
+TEST_CASE("SecurityAuditor: clean config produces no warnings", "[security][audit]") {
+    std::string config_content = R"(
+project-name: clean-project
+project-description: Project with no inline users and no MCP tools
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+)";
+
+    TempTestConfig temp(config_content, "audit_clean");
+    auto config_manager = temp.createConfigManager();
+
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE(warnings.empty());
+}
+
+TEST_CASE("SecurityAuditor: plaintext password on endpoint is flagged", "[security][audit][password]") {
+    std::string config_content = R"(
+project-name: plaintext-project
+project-description: Endpoint configured with plaintext password
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+)";
+
+    TempTestConfig temp(config_content, "audit_plaintext");
+
+    // Write an endpoint that configures Basic auth with a plaintext password
+    temp.writeEndpoint("secret.yaml", R"(
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: hunter2
+      roles: [admin]
+)");
+    temp.writeSqlTemplate("secret.sql", "SELECT 1 AS ok");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE(hasWarning(warnings, "AUTH_PLAINTEXT_PASSWORD"));
+}
+
+TEST_CASE("SecurityAuditor: MD5-hashed password is flagged as deprecated", "[security][audit][password]") {
+    std::string config_content = R"(
+project-name: md5-project
+project-description: Endpoint configured with MD5 password hash
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+)";
+
+    TempTestConfig temp(config_content, "audit_md5");
+
+    // MD5("hunter2") = 2ab96390c7dbe3439de74d0c9b0b1767
+    temp.writeEndpoint("secret.yaml", R"(
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: 2ab96390c7dbe3439de74d0c9b0b1767
+      roles: [admin]
+)");
+    temp.writeSqlTemplate("secret.sql", "SELECT 1 AS ok");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE(hasWarning(warnings, "AUTH_MD5_PASSWORD"));
+    REQUIRE_FALSE(hasWarning(warnings, "AUTH_PLAINTEXT_PASSWORD"));
+}
+
+TEST_CASE("SecurityAuditor: bcrypt password produces no warning", "[security][audit][password]") {
+    std::string config_content = R"(
+project-name: bcrypt-project
+project-description: Endpoint configured with bcrypt password hash
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+)";
+
+    TempTestConfig temp(config_content, "audit_bcrypt");
+
+    // bcrypt hash for "hunter2" (cost 4): $2b$04$abcdefghijklmnopqrstuv...
+    // Use a plausible-shape bcrypt string; classifier only inspects prefix.
+    temp.writeEndpoint("secret.yaml", R"(
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: $2b$12$Qz5e9p1m2n3o4p5q6r7s8eABCDEFGHIJKLMNOPQRSTUVWXYZabcd
+      roles: [admin]
+)");
+    temp.writeSqlTemplate("secret.sql", "SELECT 1 AS ok");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE_FALSE(hasWarning(warnings, "AUTH_PLAINTEXT_PASSWORD"));
+    REQUIRE_FALSE(hasWarning(warnings, "AUTH_MD5_PASSWORD"));
+}
+
+TEST_CASE("SecurityAuditor: MCP tool without auth is flagged", "[security][audit][mcp]") {
+    std::string config_content = R"(
+project-name: mcp-unauth-project
+project-description: MCP tool exposed without authentication
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+mcp:
+  enabled: true
+  auth:
+    enabled: false
+)";
+
+    TempTestConfig temp(config_content, "audit_mcp_noauth");
+
+    temp.writeEndpoint("lookup.yaml", R"(
+template-source: lookup.sql
+connection: [test]
+mcp-tool:
+  name: customer_lookup
+  description: Look up a customer by id
+)");
+    temp.writeSqlTemplate("lookup.sql", "SELECT 1 AS id");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE(hasWarning(warnings, "MCP_UNAUTHENTICATED_TOOLS"));
+}
+
+TEST_CASE("SecurityAuditor: MCP tool with auth enabled produces no MCP warning",
+          "[security][audit][mcp]") {
+    std::string config_content = R"(
+project-name: mcp-auth-project
+project-description: MCP tool with auth enabled
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+mcp:
+  enabled: true
+  auth:
+    enabled: true
+    type: bearer
+    jwt-secret: test-secret
+    jwt-issuer: test-issuer
+)";
+
+    TempTestConfig temp(config_content, "audit_mcp_auth");
+
+    temp.writeEndpoint("lookup.yaml", R"(
+template-source: lookup.sql
+connection: [test]
+mcp-tool:
+  name: customer_lookup
+  description: Look up a customer by id
+)");
+    temp.writeSqlTemplate("lookup.sql", "SELECT 1 AS id");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE_FALSE(hasWarning(warnings, "MCP_UNAUTHENTICATED_TOOLS"));
+}
+
+TEST_CASE("SecurityAuditor: MCP disabled overall produces no MCP warning even without auth",
+          "[security][audit][mcp]") {
+    std::string config_content = R"(
+project-name: mcp-off-project
+project-description: MCP is disabled at the top level
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+mcp:
+  enabled: false
+  auth:
+    enabled: false
+)";
+
+    TempTestConfig temp(config_content, "audit_mcp_off");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE_FALSE(hasWarning(warnings, "MCP_UNAUTHENTICATED_TOOLS"));
+}
+
+TEST_CASE("SecurityAuditor: warning carries a non-empty stable code and message",
+          "[security][audit]") {
+    std::string config_content = R"(
+project-name: shape-project
+project-description: Verifying warning shape
+http-port: 8080
+template:
+  path: ./sqls
+connections:
+  test:
+    properties:
+      path: ./data.parquet
+)";
+
+    TempTestConfig temp(config_content, "audit_shape");
+    temp.writeEndpoint("endpoint.yaml", R"(
+url-path: /endpoint
+method: GET
+template-source: endpoint.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: bob
+      password: plaintext-password
+)");
+    temp.writeSqlTemplate("endpoint.sql", "SELECT 1");
+
+    auto config_manager = temp.createConfigManager();
+    SecurityAuditor auditor;
+    auto warnings = auditor.audit(*config_manager);
+
+    REQUIRE_FALSE(warnings.empty());
+    for (const auto& w : warnings) {
+        REQUIRE_FALSE(w.code.empty());
+        REQUIRE_FALSE(w.message.empty());
+    }
+}
+
+} // namespace test
+} // namespace flapi

--- a/test/integration/test_security_warnings.py
+++ b/test/integration/test_security_warnings.py
@@ -1,0 +1,211 @@
+"""End-to-end tests for startup security warnings (issue #22, W0.2).
+
+These tests invoke the real flapi binary with crafted configurations and assert
+that the security auditor surfaces the expected warning codes on stderr. The
+binary exits cleanly via --validate-config; no server is started.
+
+Warning codes asserted here are part of the audit's public contract.
+"""
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+import yaml
+
+
+# bcrypt cost-12 hash for the literal string "hunter2" — used to verify the
+# auditor recognises a safe password and does NOT emit a warning. Cost is
+# irrelevant for classification (only the $2b$ prefix is inspected).
+BCRYPT_HUNTER2 = "$2b$12$5Q3kQqEhM2Zz5fJ7iZyqHe7eTfYpKqJzv8oU/0bI3rXlW6Tk9c1tS"
+
+# MD5("hunter2") — used to trigger the deprecated-hash warning.
+MD5_HUNTER2 = "2ab96390c7dbe3439de74d0c9b0b1767"
+
+
+@pytest.fixture
+def flapi_binary():
+    """Locate the flapi binary.
+
+    When both builds exist, prefer the more recently modified one so local TDD
+    iterations against the debug build pick up new code without a release
+    rebuild. CI environments typically build only one variant.
+    """
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    candidates = []
+    for build_type in ("release", "debug"):
+        path = os.path.join(repo_root, "build", build_type, "flapi")
+        if os.path.exists(path):
+            candidates.append(path)
+    if not candidates:
+        pytest.skip("flapi binary not found in build/release or build/debug")
+    candidates.sort(key=os.path.getmtime, reverse=True)
+    return candidates[0]
+
+
+@pytest.fixture
+def temp_config_dir():
+    """Yield a temp directory containing a sqls subdir; cleaned up on exit."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "sqls"))
+        yield tmpdir
+
+
+def _write_main_config(config_dir: str, extra: dict | None = None) -> str:
+    """Write a minimal valid flapi.yaml plus any extra keys; return its path."""
+    config = {
+        "project-name": "security-warning-test",
+        "project-description": "Integration test for startup security warnings",
+        "http-port": 8080,
+        "template": {"path": "./sqls"},
+        "connections": {
+            "test": {"properties": {"path": "./data.parquet"}}
+        },
+    }
+    if extra:
+        config.update(extra)
+    path = os.path.join(config_dir, "flapi.yaml")
+    with open(path, "w") as f:
+        yaml.dump(config, f)
+    return path
+
+
+def _write_endpoint(config_dir: str, name: str, content: str) -> None:
+    """Write an endpoint YAML and a trivial SQL template to sqls/."""
+    sqls = os.path.join(config_dir, "sqls")
+    with open(os.path.join(sqls, f"{name}.yaml"), "w") as f:
+        f.write(content)
+    with open(os.path.join(sqls, f"{name}.sql"), "w") as f:
+        f.write("SELECT 1 AS ok\n")
+
+
+def _run_validate(flapi_binary: str, config_path: str) -> subprocess.CompletedProcess:
+    """Invoke `flapi --validate-config` and return the completed process."""
+    return subprocess.run(
+        [flapi_binary, "-c", config_path, "--validate-config"],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(config_path),
+        timeout=30,
+    )
+
+
+class TestSecurityWarnings:
+    """End-to-end coverage for SecurityAuditor wiring in main.cpp."""
+
+    def test_clean_config_emits_no_security_warnings(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir)
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0, f"validate-config failed: {result.stderr}"
+        # The banner is only printed when warnings exist; absent banner == clean.
+        assert "SECURITY WARNINGS" not in (result.stderr + result.stdout)
+
+    def test_plaintext_password_emits_warning(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir)
+        _write_endpoint(temp_config_dir, "secret", """
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: hunter2
+      roles: [admin]
+""")
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0
+        combined = result.stderr + result.stdout
+        assert "AUTH_PLAINTEXT_PASSWORD" in combined, combined
+        assert "alice" in combined
+
+    def test_md5_password_emits_deprecated_warning(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir)
+        _write_endpoint(temp_config_dir, "secret", f"""
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: {MD5_HUNTER2}
+      roles: [admin]
+""")
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0
+        combined = result.stderr + result.stdout
+        assert "AUTH_MD5_PASSWORD" in combined, combined
+        assert "AUTH_PLAINTEXT_PASSWORD" not in combined, combined
+
+    def test_bcrypt_password_emits_no_warning(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir)
+        _write_endpoint(temp_config_dir, "secret", f"""
+url-path: /secret
+method: GET
+template-source: secret.sql
+connection: [test]
+auth:
+  enabled: true
+  type: basic
+  users:
+    - username: alice
+      password: {BCRYPT_HUNTER2}
+      roles: [admin]
+""")
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0
+        combined = result.stderr + result.stdout
+        assert "AUTH_PLAINTEXT_PASSWORD" not in combined, combined
+        assert "AUTH_MD5_PASSWORD" not in combined, combined
+
+    def test_unauthenticated_mcp_tool_emits_warning(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir, extra={
+            "mcp": {"enabled": True, "auth": {"enabled": False}}
+        })
+        _write_endpoint(temp_config_dir, "lookup", """
+template-source: lookup.sql
+connection: [test]
+mcp-tool:
+  name: customer_lookup
+  description: Look up a customer by id
+""")
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0
+        combined = result.stderr + result.stdout
+        assert "MCP_UNAUTHENTICATED_TOOLS" in combined, combined
+
+    def test_authenticated_mcp_tool_emits_no_mcp_warning(self, flapi_binary, temp_config_dir):
+        config_path = _write_main_config(temp_config_dir, extra={
+            "mcp": {
+                "enabled": True,
+                "auth": {
+                    "enabled": True,
+                    "type": "bearer",
+                    "jwt-secret": "test-secret",
+                    "jwt-issuer": "test-issuer",
+                },
+            }
+        })
+        _write_endpoint(temp_config_dir, "lookup", """
+template-source: lookup.sql
+connection: [test]
+mcp-tool:
+  name: customer_lookup
+  description: Look up a customer by id
+""")
+        result = _run_validate(flapi_binary, config_path)
+
+        assert result.returncode == 0
+        combined = result.stderr + result.stdout
+        assert "MCP_UNAUTHENTICATED_TOOLS" not in combined, combined


### PR DESCRIPTION
## Summary
- Adds `SecurityAuditor` that scans loaded config at startup and prints stderr warnings for plaintext / MD5 passwords on Basic-auth users and for MCP tools exposed without auth (`mcp.auth.enabled: false`). Warnings are advisory only — never block startup, no new required config.
- Corrects the docs in `CONFIG_REFERENCE.md` and `AGENTS.md` that wrongly claimed `{{{ }}}` "prevents SQL injection". It controls HTML entity escaping, not SQL escaping. Real defense is the `RequestValidator`, now stated honestly.
- Closes the W0.1 + W0.2 items of the Wave 0 child issue (#22).

## Test plan
- [x] 8 new Catch2 unit tests in `test/cpp/security_auditor_test.cpp` cover the password classifier and the audit() function over realistic configs (clean, plaintext, MD5, bcrypt, MCP auth on/off, MCP disabled).
- [x] 6 new end-to-end Python tests in `test/integration/test_security_warnings.py` invoke the real `flapi --validate-config` binary against crafted YAML and assert the warning codes appear on stderr.
- [x] `ctest -R "Security|HttpsConfig"` — 19/19 pass.
- [x] Pre-existing DuckDB ASAN failures (`user_settings.cpp` heap-use-after-free) are unrelated and untouched.
- [ ] Reviewer: confirm the auditor banner shape is acceptable; consider whether to also emit warnings under `--log-level error` (currently always printed to stderr regardless of log level).

Closes #22
Refs #21