### PR TITLE
feat(mcp): W2.1 — per-tool RBAC via mcp-tool.allowed-roles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(flapi-lib STATIC
     src/request_validator.cpp
     src/rate_limit_key_builder.cpp
     src/rate_limit_middleware.cpp
+    src/mcp_authorization_policy.cpp
     src/prepared_template_rewriter.cpp
     src/route_translator.cpp
     src/security_auditor.cpp

--- a/src/endpoint_config_parser.cpp
+++ b/src/endpoint_config_parser.cpp
@@ -162,6 +162,18 @@ void EndpointConfigParser::parseMcpToolFields(
     tool_info.name = config_manager_->safeGet<std::string>(mcp_tool_node, "name", "mcp-tool.name");
     tool_info.description = config_manager_->safeGet<std::string>(mcp_tool_node, "description", "mcp-tool.description");
     tool_info.result_mime_type = config_manager_->safeGet<std::string>(mcp_tool_node, "result-mime-type", "mcp-tool.result-mime-type", "application/json");
+
+    // Per-tool RBAC (W2.1). Absent key → std::nullopt (deny-by-default under
+    // MCP auth, transparent under demo mode). Present-but-empty list is the
+    // strict "no role passes this gate" form.
+    if (mcp_tool_node["allowed-roles"].IsDefined()) {
+        std::vector<std::string> roles;
+        for (const auto& role_node : mcp_tool_node["allowed-roles"]) {
+            roles.push_back(role_node.as<std::string>());
+        }
+        tool_info.allowed_roles = std::move(roles);
+    }
+
     config.mcp_tool = tool_info;
 }
 

--- a/src/include/config_manager.hpp
+++ b/src/include/config_manager.hpp
@@ -189,6 +189,11 @@ struct EndpointConfig {
         std::string name;
         std::string description;
         std::string result_mime_type = "application/json";
+
+        // Per-tool RBAC (W2.1). std::nullopt means "no allowed-roles configured"
+        // — under MCP auth this denies by default; with MCP auth disabled the
+        // policy short-circuits to allow. An explicit empty vector denies all.
+        std::optional<std::vector<std::string>> allowed_roles;
     };
 
     struct MCPResourceInfo {

--- a/src/include/mcp_authorization_policy.hpp
+++ b/src/include/mcp_authorization_policy.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace flapi {
+
+class EndpointConfig;
+
+class MCPAuthorizationPolicy {
+public:
+    struct Decision {
+        bool allowed = false;
+        std::string reason;
+    };
+
+    Decision authorize(const EndpointConfig& tool,
+                       const std::vector<std::string>& user_roles,
+                       bool mcp_auth_enabled) const;
+};
+
+} // namespace flapi

--- a/src/include/mcp_tool_handler.hpp
+++ b/src/include/mcp_tool_handler.hpp
@@ -9,6 +9,7 @@
 #include "audit_logger.hpp"
 #include "config_manager.hpp"
 #include "database_manager.hpp"
+#include "mcp_authorization_policy.hpp"
 #include "sql_template_processor.hpp"
 #include "request_validator.hpp"
 
@@ -25,6 +26,11 @@ struct MCPToolCallRequest {
     std::string tool_name;
     crow::json::wvalue arguments;
     std::unordered_map<std::string, std::string> context;
+
+    // Key used in `context` to pass the authenticated caller's roles
+    // through to the tool handler as a comma-separated list. Kept as a
+    // single string to keep the existing context map signature stable.
+    static constexpr const char* kRolesContextKey = "auth.roles";
 };
 
 class MCPToolHandler {
@@ -42,6 +48,12 @@ public:
     // Tool discovery
     std::vector<std::string> getAvailableTools() const;
     crow::json::wvalue getToolDefinition(const std::string& tool_name) const;
+
+    // Parse `context[kRolesContextKey]` (comma-separated) into a role list.
+    // Public so callers preparing an `MCPToolCallRequest` (and unit tests)
+    // can use the same parsing rules as `executeTool` itself.
+    static std::vector<std::string> parseRolesFromContext(
+        const std::unordered_map<std::string, std::string>& context);
 
 private:
     // Helper methods to work with unified EndpointConfig
@@ -69,6 +81,7 @@ QueryResult executeQueryWithEndpoint(const EndpointConfig& endpoint_config,
     std::shared_ptr<RequestValidator> validator;
     std::unique_ptr<SQLTemplateProcessor> sql_processor;
     std::shared_ptr<AuditLogger> audit_logger;
+    MCPAuthorizationPolicy authorization_policy;
 };
 
 } // namespace flapi

--- a/src/mcp_authorization_policy.cpp
+++ b/src/mcp_authorization_policy.cpp
@@ -1,0 +1,78 @@
+#include "mcp_authorization_policy.hpp"
+
+#include <algorithm>
+#include <sstream>
+
+#include "config_manager.hpp"
+
+namespace flapi {
+
+namespace {
+
+std::string formatRoleList(const std::vector<std::string>& roles) {
+    if (roles.empty()) {
+        return "<none>";
+    }
+    std::ostringstream oss;
+    for (size_t i = 0; i < roles.size(); ++i) {
+        if (i > 0) {
+            oss << ", ";
+        }
+        oss << roles[i];
+    }
+    return oss.str();
+}
+
+bool anyRoleMatches(const std::vector<std::string>& user_roles,
+                    const std::vector<std::string>& allowed_roles) {
+    for (const auto& user_role : user_roles) {
+        if (std::find(allowed_roles.begin(), allowed_roles.end(), user_role) != allowed_roles.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+MCPAuthorizationPolicy::Decision MCPAuthorizationPolicy::authorize(
+    const EndpointConfig& tool,
+    const std::vector<std::string>& user_roles,
+    bool mcp_auth_enabled) const
+{
+    // Policy only applies to MCP tools; non-tool endpoints are handled elsewhere.
+    if (!tool.isMCPTool()) {
+        return {true, {}};
+    }
+
+    // When the server has MCP auth turned off, the operator has opted into
+    // the open-by-default demo mode. The startup auditor warns about this;
+    // honour it here so first-run experiences keep working.
+    if (!mcp_auth_enabled) {
+        return {true, {}};
+    }
+
+    const auto& allowed = tool.mcp_tool->allowed_roles;
+    if (!allowed.has_value()) {
+        return {
+            false,
+            "Tool '" + tool.mcp_tool->name + "' has no mcp-tool.allowed-roles "
+            "configured while mcp.auth.enabled is true. Add allowed-roles to "
+            "the endpoint config to expose this tool, or disable mcp.auth to "
+            "allow anonymous access."
+        };
+    }
+
+    if (anyRoleMatches(user_roles, *allowed)) {
+        return {true, {}};
+    }
+
+    return {
+        false,
+        "Tool '" + tool.mcp_tool->name + "' requires one of [" +
+        formatRoleList(*allowed) + "]; caller has [" +
+        formatRoleList(user_roles) + "]."
+    };
+}
+
+} // namespace flapi

--- a/src/mcp_route_handlers.cpp
+++ b/src/mcp_route_handlers.cpp
@@ -862,6 +862,22 @@ MCPResponse MCPRouteHandlers::handleToolsCallRequest(const MCPRequest& request, 
                 tool_request.tool_name = tool_name;
                 tool_request.arguments = crow::json::wvalue(arguments);
 
+                // Plumb authenticated caller's roles into the tool request so the
+                // MCPToolHandler can enforce per-tool RBAC (W2.1).
+                if (auth_handler_) {
+                    auto auth_context = auth_handler_->authenticate(http_req);
+                    if (auth_context && !auth_context->roles.empty()) {
+                        std::string roles_csv;
+                        for (size_t i = 0; i < auth_context->roles.size(); ++i) {
+                            if (i > 0) {
+                                roles_csv += ",";
+                            }
+                            roles_csv += auth_context->roles[i];
+                        }
+                        tool_request.context[MCPToolCallRequest::kRolesContextKey] = roles_csv;
+                    }
+                }
+
                 auto result = tool_handler_->executeTool(tool_request);
 
                 if (result.success) {

--- a/src/mcp_tool_handler.cpp
+++ b/src/mcp_tool_handler.cpp
@@ -60,6 +60,20 @@ MCPToolExecutionResult MCPToolHandler::executeTool(const MCPToolCallRequest& req
             return createErrorResult("Tool not found: " + request.tool_name);
         }
 
+        // Per-tool RBAC check (W2.1). Runs before argument validation so a
+        // denied caller never learns the parameter shape of a tool they
+        // cannot invoke.
+        {
+            const bool mcp_auth_enabled = config_manager->getMCPConfig().auth.enabled;
+            const std::vector<std::string> user_roles = parseRolesFromContext(request.context);
+            const auto decision = authorization_policy.authorize(*endpoint_config, user_roles, mcp_auth_enabled);
+            if (!decision.allowed) {
+                CROW_LOG_WARNING << "MCP tool call denied for '" << request.tool_name
+                                 << "': " << decision.reason;
+                return createErrorResult("Permission denied: " + decision.reason);
+            }
+        }
+
         // Validate arguments
         if (!validateToolArguments(request.tool_name, request.arguments)) {
             emit_audit("error:invalid_arguments", -1);
@@ -319,6 +333,35 @@ MCPToolExecutionResult MCPToolHandler::createSuccessResult(const std::string& re
     execution_result.result = result;
     execution_result.metadata = metadata;
     return execution_result;
+}
+
+std::vector<std::string> MCPToolHandler::parseRolesFromContext(
+    const std::unordered_map<std::string, std::string>& context)
+{
+    std::vector<std::string> roles;
+    auto it = context.find(MCPToolCallRequest::kRolesContextKey);
+    if (it == context.end() || it->second.empty()) {
+        return roles;
+    }
+
+    const std::string& raw = it->second;
+    std::string::size_type start = 0;
+    while (start <= raw.size()) {
+        const auto pos = raw.find(',', start);
+        const auto end = (pos == std::string::npos) ? raw.size() : pos;
+        const auto begin = raw.find_first_not_of(" \t", start);
+        if (begin != std::string::npos && begin < end) {
+            const auto trim_end = raw.find_last_not_of(" \t", end == 0 ? 0 : end - 1);
+            if (trim_end != std::string::npos && trim_end >= begin) {
+                roles.emplace_back(raw.substr(begin, trim_end - begin + 1));
+            }
+        }
+        if (pos == std::string::npos) {
+            break;
+        }
+        start = pos + 1;
+    }
+    return roles;
 }
 
 

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(flapi_tests
     extended_yaml_parser_test.cpp
     https_config_test.cpp
     cache_manager_test.cpp
+    mcp_authorization_policy_test.cpp
     mcp_prompt_handler_test.cpp
     mcp_request_validator_test.cpp
     password_hasher_test.cpp

--- a/test/cpp/endpoint_config_parser_test.cpp
+++ b/test/cpp/endpoint_config_parser_test.cpp
@@ -86,7 +86,67 @@ connection:
     REQUIRE(result.config.isMCPTool() == true);
     REQUIRE(result.config.mcp_tool->name == "test_tool");
     REQUIRE(result.config.mcp_tool->description == "Test tool description");
-    
+    REQUIRE_FALSE(result.config.mcp_tool->allowed_roles.has_value());
+
+    fs::remove(yaml_file);
+    fs::remove(config_file);
+}
+
+TEST_CASE("EndpointConfigParser: Parse MCP Tool with allowed-roles", "[endpoint_parser][rbac]") {
+    std::string yaml_content = R"(
+mcp-tool:
+  name: gated_tool
+  description: Tool that requires a role
+  allowed-roles:
+    - analyst
+    - admin
+template-source: test.sql
+connection:
+  - test_db
+)";
+
+    std::string yaml_file = createTempYamlFile(yaml_content);
+    std::string config_file = createMinimalFlapiConfig();
+
+    ConfigManager manager{fs::path(config_file)};
+    EndpointConfigParser parser(manager.getYamlParser(), &manager);
+    auto result = parser.parseFromFile(yaml_file);
+
+    REQUIRE(result.success == true);
+    REQUIRE(result.config.isMCPTool() == true);
+    REQUIRE(result.config.mcp_tool->allowed_roles.has_value());
+    REQUIRE(result.config.mcp_tool->allowed_roles->size() == 2);
+    REQUIRE((*result.config.mcp_tool->allowed_roles)[0] == "analyst");
+    REQUIRE((*result.config.mcp_tool->allowed_roles)[1] == "admin");
+
+    fs::remove(yaml_file);
+    fs::remove(config_file);
+}
+
+TEST_CASE("EndpointConfigParser: Parse MCP Tool with empty allowed-roles list", "[endpoint_parser][rbac]") {
+    // An explicit empty list must round-trip distinctly from "absent" so the
+    // policy can treat it as the strict deny-all sentinel.
+    std::string yaml_content = R"(
+mcp-tool:
+  name: locked_tool
+  description: Locked tool, allowed-roles intentionally empty
+  allowed-roles: []
+template-source: test.sql
+connection:
+  - test_db
+)";
+
+    std::string yaml_file = createTempYamlFile(yaml_content);
+    std::string config_file = createMinimalFlapiConfig();
+
+    ConfigManager manager{fs::path(config_file)};
+    EndpointConfigParser parser(manager.getYamlParser(), &manager);
+    auto result = parser.parseFromFile(yaml_file);
+
+    REQUIRE(result.success == true);
+    REQUIRE(result.config.mcp_tool->allowed_roles.has_value());
+    REQUIRE(result.config.mcp_tool->allowed_roles->empty());
+
     fs::remove(yaml_file);
     fs::remove(config_file);
 }

--- a/test/cpp/mcp_authorization_policy_test.cpp
+++ b/test/cpp/mcp_authorization_policy_test.cpp
@@ -1,0 +1,166 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "config_manager.hpp"
+#include "mcp_authorization_policy.hpp"
+#include "mcp_tool_handler.hpp"
+
+namespace flapi {
+namespace test {
+
+namespace {
+
+EndpointConfig makeToolEndpoint(const std::string& name,
+                                std::optional<std::vector<std::string>> allowed_roles = std::nullopt) {
+    EndpointConfig endpoint;
+    EndpointConfig::MCPToolInfo info;
+    info.name = name;
+    info.description = "Test tool";
+    info.allowed_roles = std::move(allowed_roles);
+    endpoint.mcp_tool = std::move(info);
+    return endpoint;
+}
+
+} // namespace
+
+TEST_CASE("MCPAuthorizationPolicy: server auth disabled allows any caller",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("anything");
+    auto decision = policy.authorize(tool, /*user_roles=*/{}, /*mcp_auth_enabled=*/false);
+
+    REQUIRE(decision.allowed);
+    REQUIRE(decision.reason.empty());
+}
+
+TEST_CASE("MCPAuthorizationPolicy: server auth disabled allows even with declared roles",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("anything", std::vector<std::string>{"admin"});
+    auto decision = policy.authorize(tool, {"reader"}, /*mcp_auth_enabled=*/false);
+
+    REQUIRE(decision.allowed);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and no allowed-roles denies by default",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("sensitive");  // no allowed_roles
+    auto decision = policy.authorize(tool, {"admin", "user"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE_FALSE(decision.allowed);
+    REQUIRE_FALSE(decision.reason.empty());
+    REQUIRE(decision.reason.find("allowed-roles") != std::string::npos);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and matching role allows",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{"analyst", "admin"});
+    auto decision = policy.authorize(tool, {"analyst"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE(decision.allowed);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and user has multiple roles, one matches, allows",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{"admin"});
+    auto decision = policy.authorize(tool, {"user", "admin", "guest"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE(decision.allowed);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and no matching role denies",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{"admin"});
+    auto decision = policy.authorize(tool, {"user", "guest"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE_FALSE(decision.allowed);
+    REQUIRE(decision.reason.find("admin") != std::string::npos);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and empty user roles denies when roles required",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{"admin"});
+    auto decision = policy.authorize(tool, /*user_roles=*/{}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE_FALSE(decision.allowed);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: auth enabled and explicitly empty allowed-roles denies all",
+          "[security][mcp][rbac]") {
+    // An explicit empty list is the strict reading: "no role passes this gate."
+    // Operators who want anonymous access should keep mcp.auth.enabled: false.
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{});
+    auto decision = policy.authorize(tool, {"admin"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE_FALSE(decision.allowed);
+}
+
+TEST_CASE("MCPAuthorizationPolicy: role matching is case-sensitive",
+          "[security][mcp][rbac]") {
+    MCPAuthorizationPolicy policy;
+    auto tool = makeToolEndpoint("query", std::vector<std::string>{"Admin"});
+    auto decision = policy.authorize(tool, {"admin"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE_FALSE(decision.allowed);
+}
+
+TEST_CASE("MCPToolHandler::parseRolesFromContext: empty context yields empty roles",
+          "[security][mcp][rbac]") {
+    std::unordered_map<std::string, std::string> context;
+    REQUIRE(MCPToolHandler::parseRolesFromContext(context).empty());
+}
+
+TEST_CASE("MCPToolHandler::parseRolesFromContext: comma-separated list splits correctly",
+          "[security][mcp][rbac]") {
+    std::unordered_map<std::string, std::string> context{
+        {MCPToolCallRequest::kRolesContextKey, "admin,analyst,reader"}
+    };
+    auto roles = MCPToolHandler::parseRolesFromContext(context);
+    REQUIRE(roles.size() == 3);
+    REQUIRE(roles[0] == "admin");
+    REQUIRE(roles[1] == "analyst");
+    REQUIRE(roles[2] == "reader");
+}
+
+TEST_CASE("MCPToolHandler::parseRolesFromContext: whitespace around roles is trimmed",
+          "[security][mcp][rbac]") {
+    std::unordered_map<std::string, std::string> context{
+        {MCPToolCallRequest::kRolesContextKey, "  admin , analyst,  reader  "}
+    };
+    auto roles = MCPToolHandler::parseRolesFromContext(context);
+    REQUIRE(roles.size() == 3);
+    REQUIRE(roles[0] == "admin");
+    REQUIRE(roles[1] == "analyst");
+    REQUIRE(roles[2] == "reader");
+}
+
+TEST_CASE("MCPToolHandler::parseRolesFromContext: empty fragments are skipped",
+          "[security][mcp][rbac]") {
+    std::unordered_map<std::string, std::string> context{
+        {MCPToolCallRequest::kRolesContextKey, ",admin,,analyst,"}
+    };
+    auto roles = MCPToolHandler::parseRolesFromContext(context);
+    REQUIRE(roles.size() == 2);
+    REQUIRE(roles[0] == "admin");
+    REQUIRE(roles[1] == "analyst");
+}
+
+TEST_CASE("MCPAuthorizationPolicy: non-MCP endpoint short-circuits to allowed",
+          "[security][mcp][rbac]") {
+    // The policy is only meaningful for MCP tools; callers should still be
+    // defensive if asked about something that isn't a tool.
+    MCPAuthorizationPolicy policy;
+    EndpointConfig rest;
+    rest.urlPath = "/rest";
+    auto decision = policy.authorize(rest, {"admin"}, /*mcp_auth_enabled=*/true);
+
+    REQUIRE(decision.allowed);
+}
+
+} // namespace test
+} // namespace flapi

--- a/test/integration/test_mcp_rbac.py
+++ b/test/integration/test_mcp_rbac.py
@@ -1,0 +1,296 @@
+"""End-to-end tests for per-tool MCP RBAC (issue #24, W2.1).
+
+Boots a real flapi server with MCP auth enabled and two MCP tools that
+declare different `allowed-roles`. Calls each tool with JWTs carrying
+different role claims and asserts that the per-tool authorisation policy
+allows or denies as expected.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from typing import Iterator, List, Optional
+
+import pytest
+import requests
+
+
+JWT_SECRET = "rbac-test-secret"
+JWT_ISSUER = "rbac-test-issuer"
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _flapi_binary() -> str:
+    candidates: List[str] = []
+    for build_type in ("release", "debug"):
+        path = os.path.join(_repo_root(), "build", build_type, "flapi")
+        if os.path.exists(path):
+            candidates.append(path)
+    if not candidates:
+        pytest.skip("flapi binary not found in build/release or build/debug")
+    candidates.sort(key=os.path.getmtime, reverse=True)
+    return candidates[0]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
+
+
+def _make_jwt(roles: List[str], sub: str = "rbac-test-user") -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    now = int(time.time())
+    payload = {
+        "iss": JWT_ISSUER,
+        "sub": sub,
+        "roles": roles,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_b64 = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("utf-8")
+    signature = hmac.new(JWT_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{_b64url(signature)}"
+
+
+def _write_config_tree(dirpath: str, port: int) -> str:
+    """Write flapi.yaml plus two role-gated MCP tools into a temp dir."""
+    sqls = os.path.join(dirpath, "sqls")
+    os.makedirs(sqls)
+
+    flapi_yaml = f"""
+project-name: mcp-rbac-test
+project-description: Per-tool RBAC E2E
+http-port: {port}
+template:
+  path: ./sqls
+connections:
+  inmem:
+    properties:
+      database: ':memory:'
+duckdb:
+  access_mode: READ_WRITE
+  threads: 1
+mcp:
+  enabled: true
+  auth:
+    enabled: true
+    type: bearer
+    jwt-secret: {JWT_SECRET}
+    jwt-issuer: {JWT_ISSUER}
+"""
+    with open(os.path.join(dirpath, "flapi.yaml"), "w") as f:
+        f.write(flapi_yaml)
+
+    with open(os.path.join(sqls, "admin_tool.yaml"), "w") as f:
+        f.write("""
+template-source: admin_tool.sql
+connection: [inmem]
+mcp-tool:
+  name: admin_only_tool
+  description: Tool gated to the admin role
+  allowed-roles:
+    - admin
+""")
+    with open(os.path.join(sqls, "admin_tool.sql"), "w") as f:
+        f.write("SELECT 'admin-result' AS message\n")
+
+    with open(os.path.join(sqls, "analyst_tool.yaml"), "w") as f:
+        f.write("""
+template-source: analyst_tool.sql
+connection: [inmem]
+mcp-tool:
+  name: analyst_only_tool
+  description: Tool gated to the analyst role
+  allowed-roles:
+    - analyst
+""")
+    with open(os.path.join(sqls, "analyst_tool.sql"), "w") as f:
+        f.write("SELECT 'analyst-result' AS message\n")
+
+    return os.path.join(dirpath, "flapi.yaml")
+
+
+@pytest.fixture
+def rbac_server() -> Iterator[str]:
+    """Start a flapi server configured for the RBAC tests; yield base URL."""
+    binary = _flapi_binary()
+    port = _free_port()
+    with tempfile.TemporaryDirectory(prefix="flapi_rbac_") as tmpdir:
+        config_path = _write_config_tree(tmpdir, port)
+        log_path = os.path.join(tmpdir, "server.log")
+        log_file = open(log_path, "w")
+        proc = subprocess.Popen(
+            [binary, "-c", config_path, "--no-telemetry"],
+            cwd=tmpdir,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            base_url = f"http://127.0.0.1:{port}"
+            deadline = time.time() + 30
+            up = False
+            while time.time() < deadline:
+                # If the process already died, no point polling further.
+                if proc.poll() is not None:
+                    break
+                try:
+                    r = requests.get(f"{base_url}/mcp/health", timeout=1)
+                    if r.status_code < 500:
+                        up = True
+                        break
+                except requests.exceptions.RequestException:
+                    time.sleep(0.5)
+            if not up:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                log_file.close()
+                with open(log_path) as f:
+                    log_text = f.read()
+                # A locally-corrupt or version-mismatched DuckDB extension cache
+                # surfaces here as a startup crash; that's an environment fault,
+                # not a test failure. CI runs against fresh caches and exercises
+                # this path normally.
+                if "core_functions_duckdb_cpp_init" in log_text and "unique_ptr that is NULL" in log_text:
+                    pytest.skip(
+                        "flapi could not boot: local DuckDB extension cache is "
+                        "incompatible with the in-tree DuckDB submodule. "
+                        "Refresh ~/.duckdb/extensions or run this test in CI."
+                    )
+                raise RuntimeError(f"flapi failed to start. Log:\n{log_text}")
+            yield base_url
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            log_file.close()
+
+
+def _mcp_initialize(base_url: str, token: str) -> requests.Response:
+    return requests.post(
+        f"{base_url}/mcp/jsonrpc",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={
+            "jsonrpc": "2.0",
+            "id": "init-1",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "rbac-test-client", "version": "0.1"},
+                "capabilities": {},
+            },
+        },
+        timeout=10,
+    )
+
+
+def _mcp_tools_call(
+    base_url: str, token: str, tool_name: str, session_id: Optional[str] = None
+) -> requests.Response:
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    return requests.post(
+        f"{base_url}/mcp/jsonrpc",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": f"call-{tool_name}",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+        },
+        timeout=10,
+    )
+
+
+def _open_session(base_url: str, token: str) -> str:
+    """Initialize an MCP session with the given JWT and return the session id."""
+    r = _mcp_initialize(base_url, token)
+    assert r.status_code == 200, f"initialize failed: {r.status_code} {r.text}"
+    session_id = r.headers.get("Mcp-Session-Id")
+    assert session_id, f"initialize did not return Mcp-Session-Id header: {dict(r.headers)}"
+    return session_id
+
+
+@pytest.mark.standalone_server
+class TestPerToolRbac:
+    """End-to-end coverage for `mcp-tool.allowed-roles` enforcement.
+
+    Marked `standalone_server` so the conftest autouse fixture does not also
+    spin up the shared api_configuration server — each test here starts its
+    own flapi process via the `rbac_server` fixture.
+    """
+
+    def test_admin_token_can_call_admin_tool(self, rbac_server):
+        token = _make_jwt(roles=["admin"])
+        sid = _open_session(rbac_server, token)
+
+        r = _mcp_tools_call(rbac_server, token, "admin_only_tool", session_id=sid)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" not in body, f"Expected success, got error: {body}"
+        # Result is a JSON string wrapped in MCP content envelope.
+        assert "admin-result" in body["result"], body
+
+    def test_admin_token_cannot_call_analyst_tool(self, rbac_server):
+        token = _make_jwt(roles=["admin"])
+        sid = _open_session(rbac_server, token)
+
+        r = _mcp_tools_call(rbac_server, token, "analyst_only_tool", session_id=sid)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" in body, f"Expected denial, got success: {body}"
+        assert "Permission denied" in body["error"]
+        assert "analyst" in body["error"]
+
+    def test_analyst_token_can_call_analyst_tool(self, rbac_server):
+        token = _make_jwt(roles=["analyst"])
+        sid = _open_session(rbac_server, token)
+
+        r = _mcp_tools_call(rbac_server, token, "analyst_only_tool", session_id=sid)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" not in body, body
+        assert "analyst-result" in body["result"]
+
+    def test_analyst_token_cannot_call_admin_tool(self, rbac_server):
+        token = _make_jwt(roles=["analyst"])
+        sid = _open_session(rbac_server, token)
+
+        r = _mcp_tools_call(rbac_server, token, "admin_only_tool", session_id=sid)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" in body, body
+        assert "Permission denied" in body["error"]
+        assert "admin" in body["error"]
+
+    def test_token_with_no_roles_is_denied_for_role_gated_tools(self, rbac_server):
+        token = _make_jwt(roles=[])
+        sid = _open_session(rbac_server, token)
+
+        for tool in ("admin_only_tool", "analyst_only_tool"):
+            r = _mcp_tools_call(rbac_server, token, tool, session_id=sid)
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert "error" in body, f"{tool} unexpectedly allowed: {body}"
+            assert "Permission denied" in body["error"]


### PR DESCRIPTION
## Summary
- Adds opt-in per-tool RBAC: `mcp-tool.allowed-roles: [analyst, admin]` in endpoint YAML. Enforced in `MCPToolHandler::executeTool` before argument validation, so a denied caller never learns a tool's parameter shape.
- When `mcp.auth.enabled: false` (demo mode) all calls are allowed — Wave 0's startup auditor already warns. When auth is on and a tool has no `allowed-roles`, the policy denies by default and the error message names the config key to set.
- Closes W2.1 of the security roadmap (#24). This is the most direct answer to the vendor email's "RBAC permissions" pitch.

## Test plan
- [x] **14 Catch2 unit cases** in `test/cpp/mcp_authorization_policy_test.cpp` exercise every decision path of `MCPAuthorizationPolicy::authorize` plus the `parseRolesFromContext` helper (whitespace trimming, empty fragments, comma-separated parsing).
- [x] **2 new parser cases** in `test/cpp/endpoint_config_parser_test.cpp` confirm `allowed-roles` parses correctly when present, absent, and explicitly empty (the strict deny-all sentinel).
- [x] **5 end-to-end Python cases** in `test/integration/test_mcp_rbac.py` boot a real flapi server with MCP+JWT auth, configure two role-gated tools, and verify allow/deny outcomes with JWTs carrying different role claims (admin/analyst/no-roles).
- [x] `ctest -R "MCPAuthorization|parseRolesFromContext|Parse MCP Tool"` — 17/17 pass.
- [ ] **CI must validate the E2E**. The E2E fixture skips on environments with a broken local DuckDB extension cache (v1.5.1 in-tree submodule vs v1.5.2 upstream cached extensions — a pre-existing local-env mismatch); CI runs against fresh caches and exercises the full path.

## Design notes
- `MCPAuthorizationPolicy` is a single-responsibility, pure-function class — testable without a server. The handler injects it as a member.
- `MCPToolInfo::allowed_roles` is `std::optional<std::vector<std::string>>` so `nullopt` (safe default → deny under auth) is distinguishable from `[]` (explicit deny-all).
- Roles flow from `MCPAuthHandler::authenticate(http_req)` → CSV in `MCPToolCallRequest::context["auth.roles"]` → `MCPToolHandler::parseRolesFromContext` → policy. Stable key, no breaking signature change.

Closes #24
Refs #21