### PR TITLE
feat(mcp): W2.4 — per-tool response shaping (redact, cap, sample)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(flapi-lib STATIC
     src/mcp_authorization_policy.cpp
     src/mcp_description_scanner.cpp
     src/mcp_dry_run.cpp
+    src/mcp_response_shaper.cpp
     src/prepared_template_rewriter.cpp
     src/route_translator.cpp
     src/security_auditor.cpp

--- a/src/endpoint_config_parser.cpp
+++ b/src/endpoint_config_parser.cpp
@@ -196,6 +196,22 @@ void EndpointConfigParser::parseMcpToolFields(
         tool_info.allowed_roles = std::move(roles);
     }
 
+    // W2.4: parse optional response-shaping block. All fields are independent
+    // and default-inert, so leaving the block out preserves existing behaviour.
+    if (auto response_node = mcp_tool_node["response"]; response_node.IsDefined()) {
+        if (auto mr = response_node["max-rows"]; mr.IsDefined()) {
+            tool_info.response.max_rows = mr.as<std::size_t>();
+        }
+        if (auto rc = response_node["redact-columns"]; rc.IsDefined()) {
+            for (const auto& column : rc) {
+                tool_info.response.redact_columns.push_back(column.as<std::string>());
+            }
+        }
+        if (auto sample = response_node["sample"]; sample.IsDefined()) {
+            tool_info.response.sample = sample.as<bool>();
+        }
+    }
+
     config.mcp_tool = tool_info;
 }
 

--- a/src/include/config_manager.hpp
+++ b/src/include/config_manager.hpp
@@ -194,6 +194,14 @@ struct EndpointConfig {
         // — under MCP auth this denies by default; with MCP auth disabled the
         // policy short-circuits to allow. An explicit empty vector denies all.
         std::optional<std::vector<std::string>> allowed_roles;
+
+        // Per-tool response shaping (W2.4). Empty / unset → no shaping,
+        // result is returned as-is. See `MCPResponseShaper` for semantics.
+        struct ResponseShape {
+            std::optional<std::size_t> max_rows;
+            std::vector<std::string> redact_columns;
+            bool sample = false;
+        } response;
     };
 
     struct MCPResourceInfo {

--- a/src/include/mcp_response_shaper.hpp
+++ b/src/include/mcp_response_shaper.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace flapi {
+
+// Per-tool response-shaping policy (W2.4). Applied to a tool's JSON-array
+// result *after* execution and *before* it leaves the server, so the agent
+// only sees what the operator wants it to see.
+//
+// All fields are optional and inert by default — the empty config is a
+// no-op, preserving the simple-first-experience promise.
+struct ResponseShape {
+    // Cap the array length to this many rows. 0 means "all rows are
+    // suppressed"; std::nullopt means "no cap".
+    std::optional<std::size_t> max_rows;
+
+    // Replace these column values with the literal string "<redacted>"
+    // in every row. Missing columns are tolerated (no-op).
+    std::vector<std::string> redact_columns;
+
+    // When true, suppress row data entirely and emit a summary object:
+    // { row_count, columns: [...], sampled: true }.
+    bool sample = false;
+
+    bool isNoOp() const {
+        return !max_rows.has_value() && redact_columns.empty() && !sample;
+    }
+};
+
+// Pure transformer: takes a JSON payload (typically a top-level array
+// emitted by MCPToolHandler::formatResult) and applies the shape config.
+// No dependency on QueryResult, ConfigManager, or any handler internals —
+// the only contract is "JSON string in, JSON string out".
+class MCPResponseShaper {
+public:
+    static constexpr const char* kRedactedSentinel = "<redacted>";
+
+    std::string shape(const std::string& json_payload, const ResponseShape& config) const;
+};
+
+} // namespace flapi

--- a/src/mcp_response_shaper.cpp
+++ b/src/mcp_response_shaper.cpp
@@ -1,0 +1,99 @@
+#include "mcp_response_shaper.hpp"
+
+#include <algorithm>
+#include <crow/json.h>
+#include <set>
+
+namespace flapi {
+
+namespace {
+
+bool isRedacted(const std::set<std::string>& names, const std::string& key) {
+    return names.find(key) != names.end();
+}
+
+crow::json::wvalue cloneRvalue(const crow::json::rvalue& source) {
+    return crow::json::wvalue(source);
+}
+
+crow::json::wvalue redactRow(const crow::json::rvalue& row,
+                             const std::set<std::string>& redact_set) {
+    if (row.t() != crow::json::type::Object) {
+        return cloneRvalue(row);
+    }
+    crow::json::wvalue out;
+    for (const auto& key : row.keys()) {
+        if (isRedacted(redact_set, key)) {
+            out[key] = MCPResponseShaper::kRedactedSentinel;
+        } else {
+            out[key] = row[key];
+        }
+    }
+    return out;
+}
+
+std::vector<std::string> collectColumnNames(const crow::json::rvalue& array) {
+    std::vector<std::string> names;
+    if (array.t() != crow::json::type::List || array.size() == 0) {
+        return names;
+    }
+    const auto& first = array[0];
+    if (first.t() != crow::json::type::Object) {
+        return names;
+    }
+    for (const auto& key : first.keys()) {
+        names.push_back(key);
+    }
+    return names;
+}
+
+std::string buildSamplePayload(const crow::json::rvalue& array) {
+    crow::json::wvalue out;
+    out["sampled"] = true;
+    out["row_count"] = static_cast<int64_t>(array.size());
+    crow::json::wvalue columns = crow::json::wvalue::list();
+    auto names = collectColumnNames(array);
+    for (size_t i = 0; i < names.size(); ++i) {
+        columns[i] = names[i];
+    }
+    out["columns"] = std::move(columns);
+    return out.dump();
+}
+
+} // namespace
+
+std::string MCPResponseShaper::shape(const std::string& json_payload,
+                                     const ResponseShape& config) const {
+    if (config.isNoOp()) {
+        return json_payload;
+    }
+
+    auto parsed = crow::json::load(json_payload);
+    if (!parsed || parsed.t() != crow::json::type::List) {
+        // Non-array payloads (objects, primitives, malformed JSON) pass
+        // through unchanged — we don't impose row-shape semantics on them.
+        return json_payload;
+    }
+
+    if (config.sample) {
+        return buildSamplePayload(parsed);
+    }
+
+    const std::set<std::string> redact_set(
+        config.redact_columns.begin(), config.redact_columns.end());
+
+    const size_t cap = config.max_rows.has_value() ? *config.max_rows : parsed.size();
+    const size_t emit_count = std::min<size_t>(cap, parsed.size());
+
+    crow::json::wvalue out = crow::json::wvalue::list();
+    for (size_t i = 0; i < emit_count; ++i) {
+        if (redact_set.empty()) {
+            out[i] = parsed[i];
+        } else {
+            out[i] = redactRow(parsed[i], redact_set);
+        }
+    }
+    return out.dump();
+}
+
+} // namespace flapi

--- a/src/mcp_tool_handler.cpp
+++ b/src/mcp_tool_handler.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "mcp_dry_run.hpp"
+#include "mcp_response_shaper.hpp"
 
 namespace flapi {
 
@@ -161,11 +162,31 @@ MCPToolExecutionResult MCPToolHandler::executeTool(const MCPToolCallRequest& req
         std::string result_format = endpoint_config->mcp_tool ? endpoint_config->mcp_tool->result_mime_type : "application/json";
         std::string formatted_result = formatResult(query_result, result_format);
 
+        // W2.4 response shaping: redact columns / cap rows / collapse to sample
+        // summary per the tool's `mcp-tool.response` config. No-op when the
+        // operator hasn't configured anything.
+        bool shaped = false;
+        if (endpoint_config->mcp_tool) {
+            const auto& shape_yaml = endpoint_config->mcp_tool->response;
+            ResponseShape shape_config;
+            shape_config.max_rows = shape_yaml.max_rows;
+            shape_config.redact_columns = shape_yaml.redact_columns;
+            shape_config.sample = shape_yaml.sample;
+            if (!shape_config.isNoOp()) {
+                MCPResponseShaper shaper;
+                formatted_result = shaper.shape(formatted_result, shape_config);
+                shaped = true;
+            }
+        }
+
         // Create metadata
         std::unordered_map<std::string, std::string> metadata;
         metadata["tool_name"] = request.tool_name;
         metadata["query_rows"] = std::to_string(query_result.data.size());
         metadata["execution_time_ms"] = "0"; // Simplified
+        if (shaped) {
+            metadata["response_shaped"] = "true";
+        }
 
         emit_audit("success", static_cast<std::int64_t>(query_result.data.size()));
         return createSuccessResult(formatted_result, metadata);

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(flapi_tests
     mcp_dry_run_test.cpp
     mcp_prompt_handler_test.cpp
     mcp_request_validator_test.cpp
+    mcp_response_shaper_test.cpp
     password_hasher_test.cpp
     query_executor_test.cpp
     rate_limit_key_builder_test.cpp

--- a/test/cpp/endpoint_config_parser_test.cpp
+++ b/test/cpp/endpoint_config_parser_test.cpp
@@ -87,6 +87,75 @@ connection:
     REQUIRE(result.config.mcp_tool->name == "test_tool");
     REQUIRE(result.config.mcp_tool->description == "Test tool description");
     REQUIRE_FALSE(result.config.mcp_tool->allowed_roles.has_value());
+    // Default response-shape config: every field inert.
+    REQUIRE_FALSE(result.config.mcp_tool->response.max_rows.has_value());
+    REQUIRE(result.config.mcp_tool->response.redact_columns.empty());
+    REQUIRE_FALSE(result.config.mcp_tool->response.sample);
+
+    fs::remove(yaml_file);
+    fs::remove(config_file);
+}
+
+TEST_CASE("EndpointConfigParser: Parse MCP Tool with response shape config",
+          "[endpoint_parser][response_shape]") {
+    std::string yaml_content = R"(
+mcp-tool:
+  name: shaped_tool
+  description: Tool with response-shape config
+  response:
+    max-rows: 50
+    redact-columns:
+      - ssn
+      - salary
+    sample: false
+template-source: test.sql
+connection:
+  - test_db
+)";
+
+    std::string yaml_file = createTempYamlFile(yaml_content);
+    std::string config_file = createMinimalFlapiConfig();
+
+    ConfigManager manager{fs::path(config_file)};
+    EndpointConfigParser parser(manager.getYamlParser(), &manager);
+    auto result = parser.parseFromFile(yaml_file);
+
+    REQUIRE(result.success == true);
+    REQUIRE(result.config.mcp_tool->response.max_rows.has_value());
+    REQUIRE(*result.config.mcp_tool->response.max_rows == 50);
+    REQUIRE(result.config.mcp_tool->response.redact_columns.size() == 2);
+    REQUIRE(result.config.mcp_tool->response.redact_columns[0] == "ssn");
+    REQUIRE(result.config.mcp_tool->response.redact_columns[1] == "salary");
+    REQUIRE_FALSE(result.config.mcp_tool->response.sample);
+
+    fs::remove(yaml_file);
+    fs::remove(config_file);
+}
+
+TEST_CASE("EndpointConfigParser: Parse MCP Tool with sample-only response shape",
+          "[endpoint_parser][response_shape]") {
+    std::string yaml_content = R"(
+mcp-tool:
+  name: sampling_tool
+  description: Tool that returns only summary statistics
+  response:
+    sample: true
+template-source: test.sql
+connection:
+  - test_db
+)";
+
+    std::string yaml_file = createTempYamlFile(yaml_content);
+    std::string config_file = createMinimalFlapiConfig();
+
+    ConfigManager manager{fs::path(config_file)};
+    EndpointConfigParser parser(manager.getYamlParser(), &manager);
+    auto result = parser.parseFromFile(yaml_file);
+
+    REQUIRE(result.success == true);
+    REQUIRE(result.config.mcp_tool->response.sample == true);
+    REQUIRE_FALSE(result.config.mcp_tool->response.max_rows.has_value());
+    REQUIRE(result.config.mcp_tool->response.redact_columns.empty());
 
     fs::remove(yaml_file);
     fs::remove(config_file);

--- a/test/cpp/mcp_response_shaper_test.cpp
+++ b/test/cpp/mcp_response_shaper_test.cpp
@@ -1,0 +1,169 @@
+#include <catch2/catch_test_macros.hpp>
+#include <crow/json.h>
+
+#include "mcp_response_shaper.hpp"
+
+namespace flapi {
+namespace test {
+
+namespace {
+
+const std::string kThreeRowsJson = R"([
+    {"id": 1, "name": "alice", "salary": 100},
+    {"id": 2, "name": "bob",   "salary": 200},
+    {"id": 3, "name": "carol", "salary": 300}
+])";
+
+} // namespace
+
+TEST_CASE("MCPResponseShaper: default config leaves the data unchanged",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;  // all defaults
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 3);
+    REQUIRE(parsed[0]["name"].s() == std::string("alice"));
+    REQUIRE(parsed[2]["salary"].i() == 300);
+}
+
+TEST_CASE("MCPResponseShaper: max_rows truncates the array",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.max_rows = 2;
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 2);
+    REQUIRE(parsed[0]["id"].i() == 1);
+    REQUIRE(parsed[1]["id"].i() == 2);
+}
+
+TEST_CASE("MCPResponseShaper: redact_columns masks values in every row",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.redact_columns = {"salary"};
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 3);
+    for (size_t i = 0; i < parsed.size(); ++i) {
+        REQUIRE(parsed[i]["salary"].s() == std::string("<redacted>"));
+        // Non-redacted columns must survive untouched.
+        REQUIRE_FALSE(parsed[i]["name"].s() == std::string("<redacted>"));
+    }
+}
+
+TEST_CASE("MCPResponseShaper: redact + max_rows compose correctly",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.max_rows = 1;
+    config.redact_columns = {"salary", "name"};
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 1);
+    REQUIRE(parsed[0]["name"].s() == std::string("<redacted>"));
+    REQUIRE(parsed[0]["salary"].s() == std::string("<redacted>"));
+    // Non-redacted column passes through.
+    REQUIRE(parsed[0]["id"].i() == 1);
+}
+
+TEST_CASE("MCPResponseShaper: sample=true returns row count + column names only",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.sample = true;
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.has("row_count"));
+    REQUIRE(parsed["row_count"].i() == 3);
+    REQUIRE(parsed.has("columns"));
+    REQUIRE(parsed["columns"].size() == 3);
+    REQUIRE_FALSE(parsed.has("rows"));
+    REQUIRE(parsed.has("sampled"));
+    REQUIRE(parsed["sampled"].b() == true);
+}
+
+TEST_CASE("MCPResponseShaper: sample wins over redact and max_rows",
+          "[security][mcp][response_shape]") {
+    // When sample is on we never emit row data, so the other knobs are
+    // structurally inert. The test pins that contract.
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.sample = true;
+    config.max_rows = 1;
+    config.redact_columns = {"name"};
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed["row_count"].i() == 3);
+    REQUIRE_FALSE(parsed.has("rows"));
+}
+
+TEST_CASE("MCPResponseShaper: non-array input is returned unchanged",
+          "[security][mcp][response_shape]") {
+    // Defensive: handlers that already produced a non-array payload (e.g.
+    // dry-run results or empty wrapper objects) must not be corrupted.
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.max_rows = 10;
+    auto out = shaper.shape(R"({"some":"object"})", config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed["some"].s() == std::string("object"));
+}
+
+TEST_CASE("MCPResponseShaper: empty array stays empty",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.max_rows = 10;
+    config.redact_columns = {"anything"};
+    auto out = shaper.shape("[]", config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 0);
+}
+
+TEST_CASE("MCPResponseShaper: max_rows of 0 truncates everything",
+          "[security][mcp][response_shape]") {
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.max_rows = 0;
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 0);
+}
+
+TEST_CASE("MCPResponseShaper: redact-columns referring to absent column is a no-op",
+          "[security][mcp][response_shape]") {
+    // Misconfiguration shouldn't crash or alter the payload structurally.
+    MCPResponseShaper shaper;
+    ResponseShape config;
+    config.redact_columns = {"not_present"};
+    auto out = shaper.shape(kThreeRowsJson, config);
+
+    auto parsed = crow::json::load(out);
+    REQUIRE(parsed);
+    REQUIRE(parsed.size() == 3);
+    REQUIRE(parsed[0]["name"].s() == std::string("alice"));
+}
+
+} // namespace test
+} // namespace flapi

--- a/test/integration/test_mcp_response_shaping.py
+++ b/test/integration/test_mcp_response_shaping.py
@@ -1,0 +1,291 @@
+"""End-to-end tests for MCP per-tool response shaping (issue #24, W2.4).
+
+Boots a real flapi server with three MCP tools configured to test the
+three independent shaping levers:
+
+- `redact_tool` declares `redact-columns: [salary]` and must mask that
+  column in every returned row.
+- `cap_tool` declares `max-rows: 2` and must return at most two rows
+  even when the underlying SELECT yields more.
+- `sample_tool` declares `sample: true` and must return only summary
+  metadata (row_count, columns, sampled=true), no row data.
+
+Marked `standalone_server` so the conftest autouse fixture does not
+also spin up the shared api_configuration server. Skips cleanly on
+local environments where flapi cannot boot due to the v1.5.1/v1.5.2
+DuckDB extension cache mismatch; CI runs against fresh extensions.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from typing import Iterator, List
+
+import pytest
+import requests
+
+
+JWT_SECRET = "shape-test-secret"
+JWT_ISSUER = "shape-test-issuer"
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _flapi_binary() -> str:
+    candidates: List[str] = []
+    for build_type in ("release", "debug"):
+        path = os.path.join(_repo_root(), "build", build_type, "flapi")
+        if os.path.exists(path):
+            candidates.append(path)
+    if not candidates:
+        pytest.skip("flapi binary not found in build/release or build/debug")
+    candidates.sort(key=os.path.getmtime, reverse=True)
+    return candidates[0]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
+
+
+def _make_jwt(sub: str = "shape-user") -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    now = int(time.time())
+    payload = {
+        "iss": JWT_ISSUER,
+        "sub": sub,
+        "roles": ["analyst"],
+        "iat": now,
+        "exp": now + 3600,
+    }
+    h = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    p = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signature = hmac.new(JWT_SECRET.encode("utf-8"), f"{h}.{p}".encode("utf-8"), hashlib.sha256).digest()
+    return f"{h}.{p}.{_b64url(signature)}"
+
+
+def _write_config(dirpath: str, port: int) -> str:
+    sqls = os.path.join(dirpath, "sqls")
+    os.makedirs(sqls)
+
+    with open(os.path.join(dirpath, "flapi.yaml"), "w") as f:
+        f.write(
+            f"project-name: response-shape-test\n"
+            f"project-description: Response-shape E2E\n"
+            f"http-port: {port}\n"
+            f"template:\n"
+            f"  path: ./sqls\n"
+            f"connections:\n"
+            f"  inmem:\n"
+            f"    properties:\n"
+            f"      database: ':memory:'\n"
+            f"mcp:\n"
+            f"  enabled: true\n"
+            f"  auth:\n"
+            f"    enabled: true\n"
+            f"    type: bearer\n"
+            f"    jwt-secret: {JWT_SECRET}\n"
+            f"    jwt-issuer: {JWT_ISSUER}\n"
+        )
+
+    # Tool 1: redact `salary`
+    with open(os.path.join(sqls, "redact.yaml"), "w") as f:
+        f.write("""
+template-source: people.sql
+connection: [inmem]
+mcp-tool:
+  name: redact_tool
+  description: People list with salary redacted
+  response:
+    redact-columns:
+      - salary
+""")
+
+    # Tool 2: cap rows at 2
+    with open(os.path.join(sqls, "cap.yaml"), "w") as f:
+        f.write("""
+template-source: people.sql
+connection: [inmem]
+mcp-tool:
+  name: cap_tool
+  description: People list capped at 2 rows
+  response:
+    max-rows: 2
+""")
+
+    # Tool 3: sample-only
+    with open(os.path.join(sqls, "sample.yaml"), "w") as f:
+        f.write("""
+template-source: people.sql
+connection: [inmem]
+mcp-tool:
+  name: sample_tool
+  description: People list returning summary only
+  response:
+    sample: true
+""")
+
+    # All three tools share the same fixed SELECT — three rows, three columns.
+    with open(os.path.join(sqls, "people.sql"), "w") as f:
+        f.write(
+            "SELECT * FROM (VALUES "
+            "(1, 'alice', 100), "
+            "(2, 'bob', 200), "
+            "(3, 'carol', 300)"
+            ") AS t(id, name, salary)\n"
+        )
+
+    return os.path.join(dirpath, "flapi.yaml")
+
+
+@pytest.fixture
+def shape_server() -> Iterator[str]:
+    binary = _flapi_binary()
+    port = _free_port()
+    with tempfile.TemporaryDirectory(prefix="flapi_shape_") as tmpdir:
+        config_path = _write_config(tmpdir, port)
+        log_path = os.path.join(tmpdir, "server.log")
+        log_file = open(log_path, "w")
+        proc = subprocess.Popen(
+            [binary, "-c", config_path, "--no-telemetry"],
+            cwd=tmpdir,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            base_url = f"http://127.0.0.1:{port}"
+            deadline = time.time() + 30
+            up = False
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    r = requests.get(f"{base_url}/mcp/health", timeout=1)
+                    if r.status_code < 500:
+                        up = True
+                        break
+                except requests.exceptions.RequestException:
+                    time.sleep(0.5)
+            if not up:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                log_file.close()
+                with open(log_path) as f:
+                    log_text = f.read()
+                if "core_functions_duckdb_cpp_init" in log_text and "unique_ptr that is NULL" in log_text:
+                    pytest.skip(
+                        "flapi could not boot: local DuckDB extension cache is "
+                        "incompatible with the in-tree DuckDB submodule. CI exercises this path."
+                    )
+                raise RuntimeError(f"flapi failed to start. Log:\n{log_text}")
+            yield base_url
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            log_file.close()
+
+
+def _open_session(base_url: str, token: str) -> str:
+    r = requests.post(
+        f"{base_url}/mcp/jsonrpc",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={
+            "jsonrpc": "2.0",
+            "id": "init-1",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "shape-test", "version": "0.1"},
+                "capabilities": {},
+            },
+        },
+        timeout=10,
+    )
+    assert r.status_code == 200, r.text
+    sid = r.headers.get("Mcp-Session-Id")
+    assert sid, f"no session id: {dict(r.headers)}"
+    return sid
+
+
+def _tools_call(base_url: str, token: str, session_id: str, tool: str) -> requests.Response:
+    return requests.post(
+        f"{base_url}/mcp/jsonrpc",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Mcp-Session-Id": session_id,
+        },
+        json={
+            "jsonrpc": "2.0",
+            "id": f"call-{tool}",
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": {}},
+        },
+        timeout=10,
+    )
+
+
+@pytest.mark.standalone_server
+class TestResponseShaping:
+    """End-to-end coverage for `mcp-tool.response` knobs."""
+
+    def test_redact_columns_masks_listed_column(self, shape_server):
+        token = _make_jwt()
+        sid = _open_session(shape_server, token)
+        r = _tools_call(shape_server, token, sid, "redact_tool")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" not in body, f"redact_tool errored: {body}"
+        result_str = body["result"]
+        # salary must be the redaction sentinel; non-redacted columns survive.
+        assert "<redacted>" in result_str, result_str
+        assert "alice" in result_str, result_str
+        # No row should still expose a numeric salary literal.
+        assert "100" not in result_str or "<redacted>" in result_str
+
+    def test_max_rows_caps_result_set(self, shape_server):
+        token = _make_jwt()
+        sid = _open_session(shape_server, token)
+        r = _tools_call(shape_server, token, sid, "cap_tool")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" not in body, f"cap_tool errored: {body}"
+        result_str = body["result"]
+        # 2 rows max → alice and bob present, carol absent.
+        assert "alice" in result_str, result_str
+        assert "bob" in result_str, result_str
+        assert "carol" not in result_str, result_str
+
+    def test_sample_returns_summary_only(self, shape_server):
+        token = _make_jwt()
+        sid = _open_session(shape_server, token)
+        r = _tools_call(shape_server, token, sid, "sample_tool")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "error" not in body, f"sample_tool errored: {body}"
+        result_str = body["result"]
+        # Sample mode emits row_count + columns, no row data.
+        assert "\"sampled\":true" in result_str, result_str
+        assert "\"row_count\":3" in result_str, result_str
+        # None of the per-row values should appear.
+        assert "alice" not in result_str, result_str
+        assert "bob" not in result_str, result_str


### PR DESCRIPTION
## Summary
- Adds opt-in `mcp-tool.response` config with three independent knobs:
  - `redact-columns: [ssn, salary]` replaces values in every row with `"<redacted>"`.
  - `max-rows: 1000` caps the result-set length.
  - `sample: true` collapses the response to `{ row_count, columns, sampled: true }`, no rows.
- Closes W2.4 of the security roadmap (#24). With this, the vendor email's full "response inspection" pitch is covered in-product.

## Test plan
- [x] **10 Catch2 unit cases** in `test/cpp/mcp_response_shaper_test.cpp` exercise every combination — no-op, max-rows alone, redact alone, both composed, sample wins, non-array passthrough, empty array, zero cap, missing redact column.
- [x] **3 additional parser cases** prove the default tool config is inert, the full response block round-trips, and a sample-only block parses cleanly.
- [x] `ctest -R "MCPResponseShaper|response_shape|Parse MCP Tool"` — 13/13 pass.
- [x] **3 end-to-end Python cases** in `test/integration/test_mcp_response_shaping.py` boot a real flapi server with three shaped tools and verify redact, max-rows, and sample independently against a deterministic in-memory `VALUES` result. They skip cleanly in environments with the existing DuckDB v1.5.1/v1.5.2 extension-cache mismatch; CI exercises them against fresh extensions.
- [ ] Reviewer: confirm the redaction sentinel string `"<redacted>"` is acceptable, or pick a different default.

## Design notes
- `MCPResponseShaper` is a pure single-responsibility transformer: `(json_string, ResponseShape) → json_string`. No `QueryResult`, no `ConfigManager`, no handler internals — easiest possible test surface.
- `ResponseShape::isNoOp()` short-circuits the shape call when nothing is configured, so the path is free for tools without the block.
- `sample: true` deliberately wins over the other knobs — sample mode never emits row data, so combining it with `redact_columns` or `max_rows` is structurally inert. The test pins this contract.
- Non-array payloads (e.g., the dry-run JSON from #29) pass through unchanged; we don't impose row-shape semantics on objects we don't understand.

Closes part of #24
Refs #21