### PR TITLE
feat(security): W1.4 — per-user rate limiting via rate-limit.key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ add_library(flapi-lib STATIC
     src/query_executor.cpp
     src/request_handler.cpp
     src/request_validator.cpp
+    src/rate_limit_key_builder.cpp
     src/rate_limit_middleware.cpp
     src/route_translator.cpp
     src/sql_template_processor.cpp

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -534,6 +534,8 @@ void ConfigManager::parseEndpointRateLimit(const YAML::Node& endpoint_config, En
         endpoint.rate_limit.enabled = safeGet<bool>(rate_limit_node, "enabled", "rate-limit.enabled", false);
         endpoint.rate_limit.max = safeGet<int>(rate_limit_node, "max", "rate-limit.max", 100);
         endpoint.rate_limit.interval = safeGet<int>(rate_limit_node, "interval", "rate-limit.interval", 60);
+        endpoint.rate_limit.key_strategy = safeGet<std::string>(
+            rate_limit_node, "key", "rate-limit.key", rate_limit_config.key_strategy);
     }
 }
 
@@ -810,9 +812,13 @@ void ConfigManager::parseRateLimitConfig() {
         rate_limit_config.enabled = rate_limit_node["enabled"].as<bool>();
         rate_limit_config.max = rate_limit_node["max"].as<int>();
         rate_limit_config.interval = rate_limit_node["interval"].as<int>();
-        CROW_LOG_DEBUG << "Rate Limit: enabled=" << rate_limit_config.enabled 
-                       << ", max=" << rate_limit_config.max 
-                       << ", interval=" << rate_limit_config.interval;
+        if (rate_limit_node["key"]) {
+            rate_limit_config.key_strategy = rate_limit_node["key"].as<std::string>();
+        }
+        CROW_LOG_DEBUG << "Rate Limit: enabled=" << rate_limit_config.enabled
+                       << ", max=" << rate_limit_config.max
+                       << ", interval=" << rate_limit_config.interval
+                       << ", key=" << rate_limit_config.key_strategy;
     }
 }
 

--- a/src/include/config_manager.hpp
+++ b/src/include/config_manager.hpp
@@ -43,6 +43,9 @@ struct RateLimitConfig {
     bool enabled = false;
     int max = 100;
     int interval = 60;
+    // W1.4: how requests are grouped into buckets. "ip" preserves the
+    // historic default; "user" / "user-or-ip" enable per-principal limits.
+    std::string key_strategy = "ip";
 };
 
 struct AuthUser {

--- a/src/include/rate_limit_key_builder.hpp
+++ b/src/include/rate_limit_key_builder.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+
+namespace flapi {
+
+// W1.4: How the rate-limit middleware groups requests into buckets.
+// `Ip` is the historic default (per-client-ip + per-path).
+// `User` keys on the caller's `Authorization` header (hashed); all
+// requests carrying the same Authorization land in the same bucket
+// regardless of IP. Anonymous requests share one anonymous bucket.
+// `UserOrIp` uses the user identifier when an Authorization header is
+// present and falls back to the IP otherwise — useful when a deployment
+// mixes authenticated and anonymous traffic.
+enum class RateLimitKeyStrategy {
+    Ip,
+    User,
+    UserOrIp,
+};
+
+class RateLimitKeyStrategyUtils {
+public:
+    // Parse a config string into the enum. Unknown / empty values fall
+    // back to `Ip` so existing configs keep working unchanged.
+    static RateLimitKeyStrategy parse(const std::string& value);
+    static std::string toString(RateLimitKeyStrategy strategy);
+};
+
+// Pure helper: build the bucket key used by RateLimitMiddleware.
+// The output is deterministic, never contains the raw Authorization
+// value (it is hashed), and always includes the path so that two
+// endpoints stay in separate buckets even for the same caller.
+class RateLimitKeyBuilder {
+public:
+    std::string buildKey(RateLimitKeyStrategy strategy,
+                         const std::string& client_ip,
+                         const std::string& authorization_header,
+                         const std::string& path) const;
+};
+
+} // namespace flapi

--- a/src/rate_limit_key_builder.cpp
+++ b/src/rate_limit_key_builder.cpp
@@ -1,0 +1,76 @@
+#include "rate_limit_key_builder.hpp"
+
+#include <functional>
+#include <sstream>
+
+namespace flapi {
+
+namespace {
+
+constexpr const char* kAnonymousMarker = "anonymous";
+
+std::string hashAuthHeader(const std::string& authorization_header) {
+    // Stable, non-cryptographic hash of the Authorization header. We do
+    // not need cryptographic strength — we only need:
+    //   1) determinism so the same caller hashes to the same bucket
+    //   2) no plaintext token in the key (it gets logged at DEBUG)
+    // std::hash satisfies both for our purposes. Operators who want
+    // stronger guarantees should put a reverse proxy in front and key
+    // on a header it injects.
+    const std::size_t h = std::hash<std::string>{}(authorization_header);
+    std::ostringstream oss;
+    oss << "u" << std::hex << h;
+    return oss.str();
+}
+
+std::string principalForUserStrategy(const std::string& authorization_header) {
+    if (authorization_header.empty()) {
+        return std::string(kAnonymousMarker);
+    }
+    return hashAuthHeader(authorization_header);
+}
+
+} // namespace
+
+RateLimitKeyStrategy RateLimitKeyStrategyUtils::parse(const std::string& value) {
+    if (value == "user") {
+        return RateLimitKeyStrategy::User;
+    }
+    if (value == "user-or-ip") {
+        return RateLimitKeyStrategy::UserOrIp;
+    }
+    // `ip`, empty, or unknown — preserve historical behaviour.
+    return RateLimitKeyStrategy::Ip;
+}
+
+std::string RateLimitKeyStrategyUtils::toString(RateLimitKeyStrategy strategy) {
+    switch (strategy) {
+        case RateLimitKeyStrategy::Ip:        return "ip";
+        case RateLimitKeyStrategy::User:      return "user";
+        case RateLimitKeyStrategy::UserOrIp:  return "user-or-ip";
+    }
+    return "ip";
+}
+
+std::string RateLimitKeyBuilder::buildKey(RateLimitKeyStrategy strategy,
+                                          const std::string& client_ip,
+                                          const std::string& authorization_header,
+                                          const std::string& path) const {
+    std::string principal;
+    switch (strategy) {
+        case RateLimitKeyStrategy::Ip:
+            principal = client_ip;
+            break;
+        case RateLimitKeyStrategy::User:
+            principal = principalForUserStrategy(authorization_header);
+            break;
+        case RateLimitKeyStrategy::UserOrIp:
+            principal = authorization_header.empty()
+                            ? client_ip
+                            : principalForUserStrategy(authorization_header);
+            break;
+    }
+    return principal + "|" + path;
+}
+
+} // namespace flapi

--- a/src/rate_limit_middleware.cpp
+++ b/src/rate_limit_middleware.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "rate_limit_key_builder.hpp"
+
 namespace flapi {
 
 void RateLimitMiddleware::setConfig(std::shared_ptr<ConfigManager> config_manager) {
@@ -16,9 +18,17 @@ void RateLimitMiddleware::before_handle(crow::request& req, crow::response& res,
         return;
     }
 
-    // FIX #4: Include path in rate limit key (per-endpoint rate limits)
+    // W1.4: pick the bucket key based on the endpoint's `rate-limit.key`
+    // strategy (defaults to "ip" for backward compat).
     std::string client_ip = req.remote_ip_address;
-    std::string rate_key = client_ip + "|" + req.url;
+    std::string auth_header;
+    auto it = req.headers.find("Authorization");
+    if (it != req.headers.end()) {
+        auth_header = it->second;
+    }
+    const auto strategy = RateLimitKeyStrategyUtils::parse(endpoint->rate_limit.key_strategy);
+    RateLimitKeyBuilder key_builder;
+    std::string rate_key = key_builder.buildKey(strategy, client_ip, auth_header, req.url);
 
     {
         std::lock_guard<std::mutex> lock(mutex);

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(flapi_tests
     mcp_prompt_handler_test.cpp
     mcp_request_validator_test.cpp
     query_executor_test.cpp
+    rate_limit_key_builder_test.cpp
     rate_limit_middleware_test.cpp
     request_handler_test.cpp
     request_validator_test.cpp

--- a/test/cpp/rate_limit_key_builder_test.cpp
+++ b/test/cpp/rate_limit_key_builder_test.cpp
@@ -1,0 +1,121 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "rate_limit_key_builder.hpp"
+
+namespace flapi {
+namespace test {
+
+namespace {
+
+constexpr const char* kIp = "203.0.113.5";
+constexpr const char* kBearer = "Bearer abc.def.ghi";
+constexpr const char* kBearer2 = "Bearer xyz.uvw.rst";
+constexpr const char* kPath = "/customers";
+
+} // namespace
+
+TEST_CASE("RateLimitKeyBuilder: ip strategy ignores the Authorization header",
+          "[security][ratelimit]") {
+    RateLimitKeyBuilder builder;
+    auto with_auth = builder.buildKey(RateLimitKeyStrategy::Ip, kIp, kBearer, kPath);
+    auto without_auth = builder.buildKey(RateLimitKeyStrategy::Ip, kIp, "", kPath);
+    REQUIRE(with_auth == without_auth);
+    REQUIRE(with_auth.find(kIp) != std::string::npos);
+    REQUIRE(with_auth.find(kPath) != std::string::npos);
+}
+
+TEST_CASE("RateLimitKeyBuilder: user strategy yields different keys for different tokens",
+          "[security][ratelimit]") {
+    // Two callers from the same IP with different bearer tokens must
+    // end up in different buckets when key=user.
+    RateLimitKeyBuilder builder;
+    auto a = builder.buildKey(RateLimitKeyStrategy::User, kIp, kBearer, kPath);
+    auto b = builder.buildKey(RateLimitKeyStrategy::User, kIp, kBearer2, kPath);
+    REQUIRE(a != b);
+}
+
+TEST_CASE("RateLimitKeyBuilder: user strategy ignores the client IP",
+          "[security][ratelimit]") {
+    // One user reaching the same endpoint from two IPs (mobile + Wi-Fi)
+    // must stay in a single bucket when key=user.
+    RateLimitKeyBuilder builder;
+    auto a = builder.buildKey(RateLimitKeyStrategy::User, "10.0.0.1", kBearer, kPath);
+    auto b = builder.buildKey(RateLimitKeyStrategy::User, "10.0.0.2", kBearer, kPath);
+    REQUIRE(a == b);
+}
+
+TEST_CASE("RateLimitKeyBuilder: user strategy with no auth header maps to anonymous bucket",
+          "[security][ratelimit]") {
+    // Anonymous callers must not share a bucket with any real user, but
+    // they DO share a single anonymous bucket among themselves — this is
+    // intentional: anonymous traffic is the easiest to abuse, so the
+    // tightest grouping is the safest default.
+    RateLimitKeyBuilder builder;
+    auto a = builder.buildKey(RateLimitKeyStrategy::User, kIp, "", kPath);
+    auto b = builder.buildKey(RateLimitKeyStrategy::User, "10.0.0.99", "", kPath);
+    REQUIRE(a == b);
+    REQUIRE(a.find("anonymous") != std::string::npos);
+}
+
+TEST_CASE("RateLimitKeyBuilder: user-or-ip falls back to ip when auth absent",
+          "[security][ratelimit]") {
+    RateLimitKeyBuilder builder;
+    auto user_or_ip_anon = builder.buildKey(RateLimitKeyStrategy::UserOrIp, kIp, "", kPath);
+    auto ip_only = builder.buildKey(RateLimitKeyStrategy::Ip, kIp, "", kPath);
+    REQUIRE(user_or_ip_anon == ip_only);
+}
+
+TEST_CASE("RateLimitKeyBuilder: user-or-ip uses auth when present",
+          "[security][ratelimit]") {
+    RateLimitKeyBuilder builder;
+    auto user_or_ip_auth = builder.buildKey(RateLimitKeyStrategy::UserOrIp, kIp, kBearer, kPath);
+    auto user_only_auth = builder.buildKey(RateLimitKeyStrategy::User, kIp, kBearer, kPath);
+    REQUIRE(user_or_ip_auth == user_only_auth);
+}
+
+TEST_CASE("RateLimitKeyBuilder: path is part of every key for per-endpoint isolation",
+          "[security][ratelimit]") {
+    // Two endpoints hit by the same caller stay in separate buckets.
+    RateLimitKeyBuilder builder;
+    auto a = builder.buildKey(RateLimitKeyStrategy::Ip, kIp, "", "/foo");
+    auto b = builder.buildKey(RateLimitKeyStrategy::Ip, kIp, "", "/bar");
+    REQUIRE(a != b);
+}
+
+TEST_CASE("RateLimitKeyBuilder: token derivation is stable across calls",
+          "[security][ratelimit]") {
+    // The hash must be deterministic; otherwise the same caller's
+    // requests would land in different buckets and the counter would
+    // never decrement properly.
+    RateLimitKeyBuilder builder;
+    auto a = builder.buildKey(RateLimitKeyStrategy::User, kIp, kBearer, kPath);
+    auto b = builder.buildKey(RateLimitKeyStrategy::User, kIp, kBearer, kPath);
+    REQUIRE(a == b);
+}
+
+TEST_CASE("RateLimitKeyBuilder: hashed auth token does not appear verbatim in the key",
+          "[security][ratelimit]") {
+    // The raw Authorization header value is sensitive; the key is
+    // logged at debug level and persisted in the per-process map. It
+    // must not contain the bearer token in plaintext.
+    RateLimitKeyBuilder builder;
+    auto key = builder.buildKey(RateLimitKeyStrategy::User, kIp,
+                                "Bearer super-secret-token-abc123", kPath);
+    REQUIRE(key.find("super-secret-token-abc123") == std::string::npos);
+}
+
+TEST_CASE("RateLimitKeyStrategy::parse: known names map to the right enum",
+          "[security][ratelimit]") {
+    REQUIRE(RateLimitKeyStrategyUtils::parse("ip") == RateLimitKeyStrategy::Ip);
+    REQUIRE(RateLimitKeyStrategyUtils::parse("user") == RateLimitKeyStrategy::User);
+    REQUIRE(RateLimitKeyStrategyUtils::parse("user-or-ip") == RateLimitKeyStrategy::UserOrIp);
+}
+
+TEST_CASE("RateLimitKeyStrategy::parse: empty or unknown falls back to ip (backward compat)",
+          "[security][ratelimit]") {
+    REQUIRE(RateLimitKeyStrategyUtils::parse("") == RateLimitKeyStrategy::Ip);
+    REQUIRE(RateLimitKeyStrategyUtils::parse("garbage") == RateLimitKeyStrategy::Ip);
+}
+
+} // namespace test
+} // namespace flapi

--- a/test/integration/test_per_user_rate_limit.py
+++ b/test/integration/test_per_user_rate_limit.py
@@ -1,0 +1,201 @@
+"""End-to-end tests for per-user rate limiting (issue #23, W1.4).
+
+Boots flapi with a REST endpoint configured with a very low per-user
+rate limit. Two clients share the same IP but present different Bearer
+tokens. With `rate-limit.key: user-or-ip`, each gets its own quota; with
+the historic `ip` strategy, both would compete for one bucket.
+
+Marked `standalone_server` so the conftest autouse fixture does not
+spin up the shared api_configuration server. Skips cleanly when flapi
+cannot boot (local DuckDB extension cache mismatch); CI runs against
+fresh extensions.
+"""
+
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from typing import Dict, Iterator, List
+
+import pytest
+import requests
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _flapi_binary() -> str:
+    candidates: List[str] = []
+    for build_type in ("release", "debug"):
+        path = os.path.join(_repo_root(), "build", build_type, "flapi")
+        if os.path.exists(path):
+            candidates.append(path)
+    if not candidates:
+        pytest.skip("flapi binary not found in build/release or build/debug")
+    candidates.sort(key=os.path.getmtime, reverse=True)
+    return candidates[0]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _write_config(dirpath: str, port: int, key_strategy: str) -> str:
+    sqls = os.path.join(dirpath, "sqls")
+    os.makedirs(sqls)
+
+    with open(os.path.join(dirpath, "flapi.yaml"), "w") as f:
+        f.write(
+            f"project-name: per-user-rate-limit-test\n"
+            f"project-description: Per-user rate limit E2E\n"
+            f"http-port: {port}\n"
+            f"template:\n"
+            f"  path: ./sqls\n"
+            f"connections:\n"
+            f"  inmem:\n"
+            f"    properties:\n"
+            f"      database: ':memory:'\n"
+        )
+
+    # A trivial REST endpoint with a strict per-user rate limit (2 reqs / 60s).
+    # The limit is tight so the test finishes fast.
+    with open(os.path.join(sqls, "ping.yaml"), "w") as f:
+        f.write(f"""
+url-path: /ping
+method: GET
+template-source: ping.sql
+connection: [inmem]
+rate-limit:
+  enabled: true
+  max: 2
+  interval: 60
+  key: {key_strategy}
+""")
+    with open(os.path.join(sqls, "ping.sql"), "w") as f:
+        f.write("SELECT 1 AS ok\n")
+
+    return os.path.join(dirpath, "flapi.yaml")
+
+
+def _spawn_server(binary: str, config_path: str, log_path: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [binary, "-c", config_path, "--no-telemetry"],
+        cwd=os.path.dirname(config_path),
+        stdout=open(log_path, "w"),
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _wait_for_server(proc: subprocess.Popen, base_url: str, log_path: str) -> bool:
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False
+        try:
+            r = requests.get(f"{base_url}/ping", timeout=1)
+            if r.status_code < 500:
+                return True
+        except requests.exceptions.RequestException:
+            time.sleep(0.5)
+    return False
+
+
+def _maybe_skip_on_ddb_mismatch(log_path: str) -> None:
+    with open(log_path) as f:
+        log_text = f.read()
+    if "core_functions_duckdb_cpp_init" in log_text and "unique_ptr that is NULL" in log_text:
+        pytest.skip(
+            "flapi could not boot: local DuckDB extension cache is "
+            "incompatible with the in-tree DuckDB submodule. CI exercises this path."
+        )
+    raise RuntimeError(f"flapi failed to start. Log:\n{log_text}")
+
+
+@pytest.fixture
+def server_factory():
+    """Yield a callable that starts a flapi server with a given key strategy."""
+    binary = _flapi_binary()
+    started: List[subprocess.Popen] = []
+    tmpdirs: List[tempfile.TemporaryDirectory] = []
+
+    def _start(key_strategy: str) -> Dict[str, str]:
+        port = _free_port()
+        tmp = tempfile.TemporaryDirectory(prefix="flapi_rl_")
+        tmpdirs.append(tmp)
+        config_path = _write_config(tmp.name, port, key_strategy)
+        log_path = os.path.join(tmp.name, "server.log")
+        proc = _spawn_server(binary, config_path, log_path)
+        started.append(proc)
+        base_url = f"http://127.0.0.1:{port}"
+        if not _wait_for_server(proc, base_url, log_path):
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            _maybe_skip_on_ddb_mismatch(log_path)
+        return {"base_url": base_url}
+
+    yield _start
+
+    for proc in started:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    for tmp in tmpdirs:
+        tmp.cleanup()
+
+
+def _hammer(base_url: str, token: str, attempts: int) -> List[int]:
+    """Issue `attempts` GETs with the given Bearer token; return status codes."""
+    codes: List[int] = []
+    for _ in range(attempts):
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        r = requests.get(f"{base_url}/ping", headers=headers, timeout=5)
+        codes.append(r.status_code)
+    return codes
+
+
+@pytest.mark.standalone_server
+class TestPerUserRateLimit:
+    """End-to-end coverage for `rate-limit.key`."""
+
+    def test_user_or_ip_isolates_two_bearer_tokens_from_same_ip(self, server_factory):
+        # With `key: user-or-ip`, two clients sharing localhost but using
+        # different bearer tokens MUST each have their own 2-request quota.
+        # So 4 requests total succeed (2 per token), the 5th of either is 429.
+        server = server_factory("user-or-ip")
+        codes_a = _hammer(server["base_url"], "token-alice", attempts=3)
+        codes_b = _hammer(server["base_url"], "token-bob", attempts=3)
+
+        # First two for each token succeed (200 or 500 if DB env unhappy
+        # but rate-limiter didn't trip); third should be 429.
+        assert codes_a[0] != 429, f"alice's first call hit rate limit: {codes_a}"
+        assert codes_a[1] != 429, f"alice's second call hit rate limit: {codes_a}"
+        assert codes_a[2] == 429, f"alice's third call should be limited: {codes_a}"
+
+        assert codes_b[0] != 429, f"bob's first call hit rate limit: {codes_b}"
+        assert codes_b[1] != 429, f"bob's second call hit rate limit: {codes_b}"
+        assert codes_b[2] == 429, f"bob's third call should be limited: {codes_b}"
+
+    def test_ip_strategy_pools_two_bearer_tokens_into_one_bucket(self, server_factory):
+        # With the historic `key: ip` strategy, the same 4 requests share
+        # ONE bucket because the IP is identical. The third request
+        # (regardless of which token sent it) must be 429.
+        server = server_factory("ip")
+        codes_a = _hammer(server["base_url"], "token-alice", attempts=2)
+        codes_b = _hammer(server["base_url"], "token-bob", attempts=2)
+
+        # alice's two calls fit. bob's first call is the third overall →
+        # rate-limited. (bob's second is also limited.)
+        assert codes_a[0] != 429, f"alice's first call: {codes_a}"
+        assert codes_a[1] != 429, f"alice's second call: {codes_a}"
+        assert codes_b[0] == 429, (
+            f"bob's first call should be limited (3rd overall) under ip strategy: {codes_b}"
+        )


### PR DESCRIPTION
## Summary
- Adds a `key` knob to the rate-limit config that controls how requests are grouped into buckets:
  ```yaml
  rate-limit:
    enabled: true
    max: 100
    interval: 60
    key: user-or-ip       # ip | user | user-or-ip
  ```
- `ip` keeps the historic per-client-IP behaviour. `user` keys on the (hashed) `Authorization` header — two bearer tokens from the same IP land in two buckets, one user roaming between IPs stays in one bucket, anonymous traffic shares an anonymous bucket. `user-or-ip` uses the user identifier when present and falls back to IP otherwise.
- Closes W1.4 of the security roadmap (#23). Unlocks W2.5 (per-tool MCP rate limits) — the same `RateLimitKeyBuilder` will plug in once tool-specific limits land.

## Test plan
- [x] **11 Catch2 unit cases** in `test/cpp/rate_limit_key_builder_test.cpp`: ip ignores Auth, user differentiates two tokens from the same IP, user ignores IP, anonymous maps to a stable shared bucket, user-or-ip falls back correctly, path is part of every key, hashing is deterministic, raw token never appears, enum parsing handles unknown values.
- [x] `ctest -R RateLimitKey` — 11/11 pass.
- [x] **2 end-to-end Python cases** in `test/integration/test_per_user_rate_limit.py` boot real flapi servers with low quotas and verify `user-or-ip` isolates two bearer tokens at the same IP into separate quotas while `ip` pools them into one. They skip cleanly in environments with the existing DuckDB v1.5.1/v1.5.2 extension-cache mismatch; CI runs against fresh extensions.

## Design notes
- `RateLimitKeyBuilder` is a pure single-responsibility helper: `(strategy, ip, authorization_header, path) → bucket_key`. No Crow, no `ConfigManager` — testable in isolation.
- The Authorization value is hashed via `std::hash` before it lands in the bucket key. This is deliberately non-cryptographic — we only need determinism and to keep the raw token out of debug logs. Operators who want stronger guarantees can put a reverse proxy in front and key on a header it injects.
- `RateLimitKeyStrategyUtils::parse` falls back to `ip` for unknown/empty values, so fat-fingered configs do not silently flip to a different scheme.
- No middleware-ordering changes: the Authorization header is read directly from the request, so we do not depend on `AuthMiddleware` running first.

Closes #23 (rate-limit portion)
Refs #21