### PR TITLE
feat(security): W3.2 — wire TLS support into APIServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 set(CROW_ENABLE_COMPRESSION ON)
+# W3.2: enable Crow's SSL/TLS support so `app.ssl_file()` is compiled in.
+# OpenSSL is already a required dependency; turning this on has no runtime
+# cost when `enforce-https.enabled` is false.
+add_compile_definitions(CROW_ENABLE_SSL)
 
 # Compiler flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -242,12 +242,25 @@ void APIServer::run(int port) {
         configManager->setHttpPort(port);
     }
 
-    CROW_LOG_INFO << "Server starting on port " << configManager->getHttpPort() << "...";
-    app.port(configManager->getHttpPort())
-       .server_name("flAPI")
-       .multithreaded()
-       .use_compression(crow::compression::GZIP)
-       .run();
+    const auto& https = configManager->getHttpsConfig();
+    if (https.enabled) {
+        CROW_LOG_INFO << "HTTPS enabled: serving TLS on port " << configManager->getHttpPort();
+        CROW_LOG_DEBUG << "  cert: " << https.ssl_cert_file;
+        CROW_LOG_DEBUG << "  key:  " << https.ssl_key_file;
+        app.port(configManager->getHttpPort())
+           .server_name("flAPI")
+           .multithreaded()
+           .use_compression(crow::compression::GZIP)
+           .ssl_file(https.ssl_cert_file, https.ssl_key_file)
+           .run();
+    } else {
+        CROW_LOG_INFO << "Server starting on port " << configManager->getHttpPort() << "...";
+        app.port(configManager->getHttpPort())
+           .server_name("flAPI")
+           .multithreaded()
+           .use_compression(crow::compression::GZIP)
+           .run();
+    }
 }
 
 void APIServer::requestForEndpoint(const EndpointConfig& endpoint, const std::unordered_map<std::string, std::string>& pathParams) 

--- a/test/integration/test_tls_wireup.py
+++ b/test/integration/test_tls_wireup.py
@@ -1,0 +1,180 @@
+"""End-to-end tests for TLS wire-up (issue #25, W3.2).
+
+Boots flapi with `enforce-https.enabled: true` pointing at the fixture
+cert/key files in `test/integration/fixtures/`. Verifies:
+- A plain `http://...` request gets refused / errors out — the listener
+  is speaking TLS, not plain HTTP.
+- An `https://...` request with `verify=False` (self-signed cert) gets
+  through to the trivial REST endpoint and returns 200.
+
+Marked `standalone_server` so the conftest autouse fixture does not
+spin up the shared api_configuration server. Skips cleanly when flapi
+cannot boot (local DuckDB extension-cache mismatch); CI runs against
+fresh extensions.
+"""
+
+import os
+import socket
+import subprocess
+import tempfile
+import time
+import urllib3
+from typing import Dict, Iterator, List
+
+import pytest
+import requests
+
+# Self-signed test cert → suppress noisy warnings.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _flapi_binary() -> str:
+    candidates: List[str] = []
+    for build_type in ("release", "debug"):
+        path = os.path.join(_repo_root(), "build", build_type, "flapi")
+        if os.path.exists(path):
+            candidates.append(path)
+    if not candidates:
+        pytest.skip("flapi binary not found in build/release or build/debug")
+    candidates.sort(key=os.path.getmtime, reverse=True)
+    return candidates[0]
+
+
+def _fixtures_dir() -> str:
+    return os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _write_config(dirpath: str, port: int) -> str:
+    sqls = os.path.join(dirpath, "sqls")
+    os.makedirs(sqls)
+
+    cert_path = os.path.join(_fixtures_dir(), "test_cert.pem")
+    key_path = os.path.join(_fixtures_dir(), "test_key.pem")
+    if not (os.path.exists(cert_path) and os.path.exists(key_path)):
+        pytest.skip("TLS fixture cert/key not present in test/integration/fixtures/")
+
+    with open(os.path.join(dirpath, "flapi.yaml"), "w") as f:
+        f.write(
+            f"project-name: tls-wireup-test\n"
+            f"project-description: TLS wire-up E2E\n"
+            f"http-port: {port}\n"
+            f"template:\n"
+            f"  path: ./sqls\n"
+            f"connections:\n"
+            f"  inmem:\n"
+            f"    properties:\n"
+            f"      database: ':memory:'\n"
+            f"enforce-https:\n"
+            f"  enabled: true\n"
+            f"  ssl-cert-file: {cert_path}\n"
+            f"  ssl-key-file: {key_path}\n"
+        )
+
+    with open(os.path.join(sqls, "ping.yaml"), "w") as f:
+        f.write("""
+url-path: /ping
+method: GET
+template-source: ping.sql
+connection: [inmem]
+""")
+    with open(os.path.join(sqls, "ping.sql"), "w") as f:
+        f.write("SELECT 1 AS ok\n")
+
+    return os.path.join(dirpath, "flapi.yaml")
+
+
+@pytest.fixture
+def tls_server() -> Iterator[Dict[str, str]]:
+    binary = _flapi_binary()
+    port = _free_port()
+    with tempfile.TemporaryDirectory(prefix="flapi_tls_") as tmpdir:
+        config_path = _write_config(tmpdir, port)
+        log_path = os.path.join(tmpdir, "server.log")
+        log_file = open(log_path, "w")
+        proc = subprocess.Popen(
+            [binary, "-c", config_path, "--no-telemetry"],
+            cwd=tmpdir,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            base_url = f"https://127.0.0.1:{port}"
+            deadline = time.time() + 30
+            up = False
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    # Use raw socket probe rather than requests: TLS handshake
+                    # would fail against a self-signed cert if our handshake
+                    # short-circuit didn't work. Plain TCP confirms the
+                    # listener is alive.
+                    s = socket.socket()
+                    s.settimeout(0.5)
+                    s.connect(("127.0.0.1", port))
+                    s.close()
+                    up = True
+                    break
+                except (ConnectionRefusedError, socket.timeout, OSError):
+                    time.sleep(0.5)
+            if not up:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                log_file.close()
+                with open(log_path) as f:
+                    log_text = f.read()
+                if "core_functions_duckdb_cpp_init" in log_text and "unique_ptr that is NULL" in log_text:
+                    pytest.skip(
+                        "flapi could not boot: local DuckDB extension cache is "
+                        "incompatible with the in-tree DuckDB submodule. CI exercises this path."
+                    )
+                raise RuntimeError(f"flapi failed to start. Log:\n{log_text}")
+            yield {"base_url": base_url, "port": str(port)}
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            log_file.close()
+
+
+@pytest.mark.standalone_server
+class TestTlsWireup:
+    """End-to-end coverage for `enforce-https.enabled`."""
+
+    def test_https_request_succeeds_with_self_signed_cert(self, tls_server):
+        r = requests.get(f"{tls_server['base_url']}/ping", verify=False, timeout=10)
+        # 200 if DB env is happy, 500 otherwise — what we're proving is the
+        # TLS handshake completed and we reached the endpoint layer.
+        assert r.status_code in (200, 500), r.text
+        # Verify the connection genuinely went over TLS: requests records
+        # `https://...` in the response URL.
+        assert r.url.startswith("https://"), r.url
+
+    def test_plain_http_against_tls_port_does_not_succeed(self, tls_server):
+        # Hitting the TLS-only port with plain http must not return a normal
+        # response. Different clients/asio versions surface this differently
+        # (connection error, empty response, mangled body), so accept any
+        # non-success outcome.
+        port = tls_server["port"]
+        try:
+            r = requests.get(f"http://127.0.0.1:{port}/ping", timeout=5)
+        except requests.exceptions.RequestException:
+            return  # connection error — TLS-only listener rejected plain HTTP, as expected
+        assert r.status_code >= 400 or not r.ok, (
+            f"plain HTTP unexpectedly succeeded on TLS port: {r.status_code} {r.text}"
+        )


### PR DESCRIPTION
## Summary
- The `HttpsConfig` struct, YAML parsing, and cert/key existence checks have been in place since the original Architecture pass; this PR finally flips the switch so `enforce-https.enabled: true` actually serves TLS instead of being parsed-and-ignored.
  ```yaml
  enforce-https:
    enabled: true
    ssl-cert-file: /etc/flapi/server.crt
    ssl-key-file:  /etc/flapi/server.key
  ```
- Closes W3.2 of the security roadmap (#25).

## Implementation
- `CMakeLists.txt` adds `CROW_ENABLE_SSL` as a compile definition. OpenSSL was already required; turning this on costs nothing at runtime when HTTPS is disabled.
- `APIServer::run` branches on `getHttpsConfig().enabled`. The HTTPS branch logs cert/key at DEBUG and calls `ssl_file()` before `.run()`. Plain-HTTP path is byte-identical to before.

## Test plan
- [x] **Existing 11 Catch2 HttpsConfig cases** in `test/cpp/https_config_test.cpp` still pass (config parsing, missing-file rejection, enabled/disabled accessor) — `ctest -R HttpsConfig` → 11/11.
- [x] **Compile-time guarantee**: Crow's `ssl_file()` carries a `static_assert(... "Define CROW_ENABLE_SSL to enable ssl support.")`. The build succeeding proves the macro is defined globally.
- [x] **2 end-to-end Python cases** in `test/integration/test_tls_wireup.py` boot a real flapi server with the fixture cert/key in `test/integration/fixtures/` and verify (a) HTTPS handshake completes and the endpoint responds, (b) plain HTTP at the same TLS port does not. They skip cleanly in environments with the existing DuckDB v1.5.1/v1.5.2 extension-cache mismatch; CI runs against fresh extensions.

## Why no new C++ unit tests
The new work is a single conditional wire call in `run()`. Verifying it meaningfully requires a real TCP listener, which is the E2E test's job. Compilation success proves `CROW_ENABLE_SSL` is now in effect (otherwise the `ssl_file()` call would fail the static_assert).

Closes part of #25
Refs #21