### PR TITLE
fix: Embed JSON-aliased VARCHAR columns as nested JSON (#38)

### DIFF
--- a/src/include/query_executor.hpp
+++ b/src/include/query_executor.hpp
@@ -48,6 +48,7 @@ private:
 
     static crow::json::wvalue convertVectorEntryToJson(const duckdb_vector &vector, const idx_t row_idx);
     static crow::json::wvalue convertVectorVarcharToJson(const duckdb_vector &vector, const idx_t row_idx);
+    static crow::json::wvalue convertVectorJsonToJson(const duckdb_vector &vector, const idx_t row_idx);
     static crow::json::wvalue convertVectorDecimalToJson(const duckdb_vector &vector, const idx_t row_idx);
     static crow::json::wvalue convertVectorTimestampToJson(const duckdb_vector &vector, const idx_t row_idx);
     static crow::json::wvalue convertVectorDateToJson(const duckdb_vector &vector, const idx_t row_idx);

--- a/src/query_executor.cpp
+++ b/src/query_executor.cpp
@@ -203,6 +203,23 @@ std::vector<crow::json::wvalue> QueryResult::convertChunkToJson(const std::vecto
 crow::json::wvalue QueryResult::convertVectorEntryToJson(const duckdb_vector &vector, const idx_t row_idx) {
     auto type = duckdb_vector_get_column_type(vector);
     auto type_id = duckdb_get_type_id(type);
+
+    // DuckDB's JSON type is a logical-type alias over VARCHAR (see
+    // DuckDB's LogicalType::JSON()), so `duckdb_get_type_id` returns
+    // VARCHAR for it. Detect the alias before dispatching to the VARCHAR
+    // handler so JSON columns are embedded as nested JSON rather than
+    // emitted as escaped strings.
+    bool is_json_alias = false;
+    if (type_id == DUCKDB_TYPE_VARCHAR) {
+        DuckDBString alias(duckdb_logical_type_get_alias(type));
+        is_json_alias = !alias.is_null() && std::string(alias.get()) == "JSON";
+    }
+    duckdb_destroy_logical_type(&type);
+
+    if (is_json_alias) {
+        return convertVectorJsonToJson(vector, row_idx);
+    }
+
     switch (type_id) {
         case DUCKDB_TYPE_SQLNULL:
             return crow::json::wvalue(nullptr);
@@ -278,9 +295,6 @@ crow::json::wvalue QueryResult::convertVectorEntryToJson(const duckdb_vector &ve
             CROW_LOG_WARNING << "Unknown type: " << type_id;
             return crow::json::wvalue(nullptr);
     }
-
-    duckdb_destroy_logical_type(&type);
-    return crow::json::wvalue();
 }
 
 crow::json::wvalue QueryResult::convertVectorVarcharToJson(const duckdb_vector &vector, const idx_t row_idx) {
@@ -288,13 +302,37 @@ crow::json::wvalue QueryResult::convertVectorVarcharToJson(const duckdb_vector &
     if (!duckdb_validity_row_is_valid(validity, row_idx)) {
         return crow::json::wvalue(nullptr);
     }
-    
+
     auto data = (duckdb_string_t *)duckdb_vector_get_data(vector);
     auto str = duckdb_string_is_inlined(data[row_idx])
              ? std::string(data[row_idx].value.inlined.inlined, data[row_idx].value.inlined.length)
              : std::string((const char*)data[row_idx].value.pointer.ptr, data[row_idx].value.pointer.length);
 
     return crow::json::wvalue(str);
+}
+
+crow::json::wvalue QueryResult::convertVectorJsonToJson(const duckdb_vector &vector, const idx_t row_idx) {
+    auto validity = duckdb_vector_get_validity(vector);
+    if (!duckdb_validity_row_is_valid(validity, row_idx)) {
+        return crow::json::wvalue(nullptr);
+    }
+
+    auto data = (duckdb_string_t *)duckdb_vector_get_data(vector);
+    const char* str_ptr = duckdb_string_is_inlined(data[row_idx])
+                        ? data[row_idx].value.inlined.inlined
+                        : (const char*)data[row_idx].value.pointer.ptr;
+    const idx_t str_len = duckdb_string_is_inlined(data[row_idx])
+                        ? data[row_idx].value.inlined.length
+                        : data[row_idx].value.pointer.length;
+
+    auto parsed = crow::json::load(str_ptr, str_len);
+    if (!parsed) {
+        // Source row contains malformed JSON; degrade to the raw string
+        // rather than dropping the row or returning null. The cell stays
+        // queryable, just as a string.
+        return crow::json::wvalue(std::string(str_ptr, str_len));
+    }
+    return crow::json::wvalue(parsed);
 }
 
 crow::json::wvalue QueryResult::convertVectorDecimalToJson(const duckdb_vector &vector, const idx_t row_idx) {

--- a/test/cpp/query_executor_test.cpp
+++ b/test/cpp/query_executor_test.cpp
@@ -79,6 +79,76 @@ TEST_CASE("QueryExecutor error handling", "[query_executor]") {
     duckdb_close(&database);
 }
 
+TEST_CASE("QueryExecutor JSON column", "[query_executor][json]") {
+    duckdb_database database;
+    REQUIRE(duckdb_open(NULL, &database) == DuckDBSuccess);
+
+    QueryExecutor executor(database);
+    executor.execute("INSTALL json; LOAD json;");
+
+    SECTION("nested JSON value is embedded, not escaped") {
+        // Reproduction from issue #38: a column with the DuckDB `JSON`
+        // logical-type alias must serialise as nested JSON, not as a
+        // JSON-escaped string the caller has to parse a second time.
+        executor.execute(R"SQL(
+            SELECT
+                1 AS id,
+                '{"a": 1, "b": [10, 20], "c": {"nested": true}}'::JSON AS payload
+        )SQL");
+
+        auto doc = crow::json::load(executor.toJson().dump());
+        REQUIRE(doc.size() == 1);
+        REQUIRE(doc[0]["id"].i() == 1);
+
+        // The crux: payload must be an Object, not a String.
+        REQUIRE(doc[0]["payload"].t() == crow::json::type::Object);
+        REQUIRE(doc[0]["payload"]["a"].i() == 1);
+        REQUIRE(doc[0]["payload"]["b"].t() == crow::json::type::List);
+        REQUIRE(doc[0]["payload"]["b"].size() == 2);
+        REQUIRE(doc[0]["payload"]["b"][0].i() == 10);
+        REQUIRE(doc[0]["payload"]["b"][1].i() == 20);
+        REQUIRE(doc[0]["payload"]["c"]["nested"].b() == true);
+    }
+
+    SECTION("JSON array column is embedded as array") {
+        executor.execute(R"SQL(
+            SELECT '[1, 2, 3]'::JSON AS arr
+        )SQL");
+
+        auto doc = crow::json::load(executor.toJson().dump());
+        REQUIRE(doc.size() == 1);
+        REQUIRE(doc[0]["arr"].t() == crow::json::type::List);
+        REQUIRE(doc[0]["arr"].size() == 3);
+        REQUIRE(doc[0]["arr"][0].i() == 1);
+        REQUIRE(doc[0]["arr"][2].i() == 3);
+    }
+
+    SECTION("NULL JSON column stays null") {
+        executor.execute(R"SQL(
+            SELECT CAST(NULL AS JSON) AS payload
+        )SQL");
+
+        auto doc = crow::json::load(executor.toJson().dump());
+        REQUIRE(doc.size() == 1);
+        REQUIRE(doc[0]["payload"].t() == crow::json::type::Null);
+    }
+
+    SECTION("plain VARCHAR is still emitted as a string") {
+        // Regression guard: only the JSON-aliased VARCHAR path changes;
+        // bare VARCHAR must continue to render as a JSON string.
+        executor.execute(R"SQL(
+            SELECT '{"looks":"like json"}'::VARCHAR AS not_json
+        )SQL");
+
+        auto doc = crow::json::load(executor.toJson().dump());
+        REQUIRE(doc.size() == 1);
+        REQUIRE(doc[0]["not_json"].t() == crow::json::type::String);
+        REQUIRE(doc[0]["not_json"].s() == "{\"looks\":\"like json\"}");
+    }
+
+    duckdb_close(&database);
+}
+
 TEST_CASE("QueryExecutor type coverage", "[query_executor]") {
     duckdb_database database;
     REQUIRE(duckdb_open(NULL, &database) == DuckDBSuccess);

--- a/test/integration/api_configuration/sqls/json_demo.sql
+++ b/test/integration/api_configuration/sqls/json_demo.sql
@@ -1,0 +1,5 @@
+-- Reproduction of issue #38. `::JSON` triggers DuckDB's autoload of the
+-- json extension, so no explicit LOAD is needed here.
+SELECT
+    1 AS id,
+    '{"a": 1, "b": [10, 20], "c": {"nested": true}}'::JSON AS payload

--- a/test/integration/api_configuration/sqls/json_demo.yaml
+++ b/test/integration/api_configuration/sqls/json_demo.yaml
@@ -1,0 +1,16 @@
+# Reproduces issue #38: a DuckDB JSON-aliased VARCHAR column must serialise
+# as nested JSON, not as a JSON-escaped string the caller has to parse a
+# second time. The endpoint returns the literal payload from the issue's
+# reproduction so a test can assert on the structure directly.
+url-path: /json-demo/
+method: GET
+
+template-source: json_demo.sql
+
+# A connection is required by the endpoint loader; the SQL itself does not
+# touch the connection, so the existing parquet connection works.
+connection:
+  - data-types-parquet
+
+auth:
+  enabled: false

--- a/test/integration/test_json_column.tavern.yaml
+++ b/test/integration/test_json_column.tavern.yaml
@@ -1,0 +1,26 @@
+# Regression test for issue #38:
+# A column declared as DuckDB's JSON logical type must appear in the HTTP
+# response body as a nested JSON object, not as a JSON-escaped string.
+test_name: JSON-aliased VARCHAR columns are returned as nested JSON
+
+stages:
+  - name: GET /json-demo embeds payload as a nested object
+    request:
+      url: "{base_url}/json-demo/"
+      method: GET
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      json:
+        data:
+          - id: 1
+            payload:
+              a: 1
+              b:
+                - 10
+                - 20
+              c:
+                nested: true
+        next: !anything
+        total_count: !anything


### PR DESCRIPTION
## Summary

Closes #38.

When a query returns a column whose DuckDB logical type is `JSON`, flAPI emitted the raw text as a JSON-escaped string in the REST response, forcing consumers to `JSON.parse` the value a second time. The reporter (BigQuery tree with recursive `children` arrays typed as `JSON`) correctly identified the dispatch site: `QueryResult::convertVectorEntryToJson` switches on `duckdb_get_type_id(type)`, which returns the *physical* type id. DuckDB's `JSON` is a logical-type alias over `VARCHAR`, so the cell fell into the `DUCKDB_TYPE_VARCHAR` branch and got wrapped as a `crow::json::wvalue(str)`.

### Fix

- Inspect the logical type's alias via `duckdb_logical_type_get_alias` before dispatching VARCHAR. When it equals the literal `"JSON"` that DuckDB itself sets on `LogicalType::JSON()`, route to a new `convertVectorJsonToJson` helper that parses the bytes with `crow::json::load` and embeds the parsed value via the `wvalue(const rvalue&)` constructor. Nested objects and arrays now travel through the response unchanged. Malformed JSON degrades to the raw string rather than nulling the row.
- Destroy the logical type allocated at the top of `convertVectorEntryToJson` on every exit path. The dead `duckdb_destroy_logical_type` below the switch was unreachable, leaking one logical-type allocation per emitted cell (~24 bytes each, visible under ASan: removed 13/15 leak allocations the suite reports).

Both changes are scoped to `src/query_executor.cpp` and `src/include/query_executor.hpp`. The Arrow output path has the same physical-id dispatch in `arrow_serializer.hpp` but Arrow conventionally represents JSON via metadata/extension types, so it is intentionally out of scope for this PR.

### Tests

Built TDD-style — failing tests landed first, then the fix.

Unit tests (`test/cpp/query_executor_test.cpp`, new `[json]` tag):
- Nested JSON object is embedded as Object (reproduces the issue exactly).
- JSON array column is embedded as List.
- `CAST(NULL AS JSON)` stays Null.
- Plain VARCHAR continues to render as a JSON string (regression guard).

Integration test (`test/integration/test_json_column.tavern.yaml` + supporting `sqls/json_demo.{yaml,sql}`):
- `GET /json-demo/` returns the exact "Expected" shape from issue #38.

End-to-end verification with a debug-instrumented server confirmed the alias path fires (`type_id=17 alias=JSON is_json=1`) and the response body now matches the issue's expected output:

```json
{"data":[{"id":1,"payload":{"a":1,"b":[10,20],"c":{"nested":true}}}],"total_count":1,"next":""}
```

## Test plan

- [x] New unit cases pass (`flapi_tests "QueryExecutor JSON column"` — 23/23 assertions).
- [x] Full `[query_executor]` suite green (1092/1092 assertions, 7 cases).
- [x] Full `ctest` suite — 586/587 pass; the lone failure (`CachingFileProvider thread safety_test`) is pre-existing and reproduces on stash-popped pre-change code.
- [x] End-to-end response of `GET /json-demo/` matches the issue's expected JSON.
- [ ] CI matrix (Linux x86/ARM64, macOS ARM64, Windows x64, flapii) — will be exercised by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERKg9gQDBzccRDbSePXb4p)_