### PR TITLE
feat(self-packaging #41): libarchive + archive_io RAII wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ find_package(jwt-cpp CONFIG REQUIRED)
 find_package(argparse CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(CURL CONFIG REQUIRED)
+find_package(LibArchive REQUIRED)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -229,6 +230,7 @@ include_directories(
 # Create flapi-lib
 add_library(flapi-lib STATIC
     src/api_server.cpp
+    src/archive_io.cpp
     src/audit_logger.cpp
     src/auth_middleware.cpp
     src/cache_manager.cpp
@@ -312,6 +314,7 @@ target_link_libraries(flapi-lib PUBLIC
     ${AWSSDK_LIBRARIES}
     fmt::fmt
     CURL::libcurl
+    LibArchive::LibArchive
     nanoarrow::nanoarrow
     nanoarrow::nanoarrow_ipc
     $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>

--- a/src/archive_io.cpp
+++ b/src/archive_io.cpp
@@ -1,0 +1,200 @@
+#include "archive_io.hpp"
+
+#include <archive.h>
+#include <archive_entry.h>
+
+#include <array>
+#include <cstring>
+#include <ctime>
+#include <utility>
+
+namespace flapi {
+
+namespace {
+
+struct WriteSink {
+    std::vector<std::uint8_t>* out;
+};
+
+la_ssize_t WriteCallback(archive*, void* client_data, const void* buffer, std::size_t length) {
+    auto* sink = static_cast<WriteSink*>(client_data);
+    const auto* bytes = static_cast<const std::uint8_t*>(buffer);
+    sink->out->insert(sink->out->end(), bytes, bytes + length);
+    return static_cast<la_ssize_t>(length);
+}
+
+std::string ArchiveErrorMessage(archive* a, const char* prefix) {
+    const char* err = archive_error_string(a);
+    std::string msg = prefix;
+    msg += ": ";
+    msg += err ? err : "unknown libarchive error";
+    return msg;
+}
+
+class ScopedWriter {
+public:
+    ScopedWriter() : a_(archive_write_new()) {}
+    ~ScopedWriter() {
+        if (a_ != nullptr) {
+            archive_write_free(a_);
+        }
+    }
+    ScopedWriter(const ScopedWriter&) = delete;
+    ScopedWriter& operator=(const ScopedWriter&) = delete;
+
+    archive* get() const { return a_; }
+
+private:
+    archive* a_;
+};
+
+class ScopedReader {
+public:
+    ScopedReader() : a_(archive_read_new()) {}
+    ~ScopedReader() {
+        if (a_ != nullptr) {
+            archive_read_free(a_);
+        }
+    }
+    ScopedReader(const ScopedReader&) = delete;
+    ScopedReader& operator=(const ScopedReader&) = delete;
+
+    archive* get() const { return a_; }
+
+private:
+    archive* a_;
+};
+
+class ScopedEntry {
+public:
+    ScopedEntry() : e_(archive_entry_new()) {}
+    ~ScopedEntry() {
+        if (e_ != nullptr) {
+            archive_entry_free(e_);
+        }
+    }
+    ScopedEntry(const ScopedEntry&) = delete;
+    ScopedEntry& operator=(const ScopedEntry&) = delete;
+
+    archive_entry* get() const { return e_; }
+
+private:
+    archive_entry* e_;
+};
+
+}  // namespace
+
+std::vector<std::uint8_t> WriteArchive(const ArchiveEntries& entries,
+                                       const ArchiveWriteOptions& options) {
+    std::vector<std::uint8_t> out;
+    WriteSink sink{&out};
+
+    ScopedWriter writer;
+    if (writer.get() == nullptr) {
+        throw ArchiveIOError("archive_write_new returned null");
+    }
+    archive* a = writer.get();
+
+    if (archive_write_set_format_zip(a) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_write_set_format_zip"));
+    }
+
+    // Critical: keep the spike-found "no tar-block padding" property so a
+    // later EOCD reverse scan finds the record at file EOF (or close to it)
+    // instead of after a chunk of trailing zeros.
+    if (archive_write_set_bytes_in_last_block(a, 1) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_write_set_bytes_in_last_block"));
+    }
+
+    if (archive_write_open(a, &sink, /*open=*/nullptr, WriteCallback, /*close=*/nullptr) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_write_open"));
+    }
+
+    const std::time_t mtime = static_cast<std::time_t>(options.source_date_epoch.value_or(0));
+
+    for (const auto& [name, data] : entries) {
+        ScopedEntry entry;
+        if (entry.get() == nullptr) {
+            throw ArchiveIOError("archive_entry_new returned null");
+        }
+        archive_entry_set_pathname(entry.get(), name.c_str());
+        archive_entry_set_size(entry.get(), static_cast<la_int64_t>(data.size()));
+        archive_entry_set_filetype(entry.get(), AE_IFREG);
+        archive_entry_set_perm(entry.get(), 0644);
+        archive_entry_set_mtime(entry.get(), mtime, 0);
+        archive_entry_set_atime(entry.get(), mtime, 0);
+        archive_entry_set_ctime(entry.get(), mtime, 0);
+
+        if (archive_write_header(a, entry.get()) != ARCHIVE_OK) {
+            throw ArchiveIOError(ArchiveErrorMessage(a, ("archive_write_header(" + name + ")").c_str()));
+        }
+
+        if (!data.empty()) {
+            const la_ssize_t written = archive_write_data(a, data.data(), data.size());
+            if (written < 0 || static_cast<std::size_t>(written) != data.size()) {
+                throw ArchiveIOError(ArchiveErrorMessage(a, ("archive_write_data(" + name + ")").c_str()));
+            }
+        }
+    }
+
+    if (archive_write_close(a) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_write_close"));
+    }
+
+    return out;
+}
+
+ArchiveEntries ReadArchive(const std::vector<std::uint8_t>& buffer) {
+    if (buffer.empty()) {
+        throw ArchiveIOError("archive buffer is empty");
+    }
+
+    ScopedReader reader;
+    if (reader.get() == nullptr) {
+        throw ArchiveIOError("archive_read_new returned null");
+    }
+    archive* a = reader.get();
+
+    if (archive_read_support_format_zip(a) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_read_support_format_zip"));
+    }
+
+    if (archive_read_open_memory(a, buffer.data(), buffer.size()) != ARCHIVE_OK) {
+        throw ArchiveIOError(ArchiveErrorMessage(a, "archive_read_open_memory"));
+    }
+
+    ArchiveEntries result;
+    archive_entry* entry = nullptr;
+
+    while (true) {
+        const int rc = archive_read_next_header(a, &entry);
+        if (rc == ARCHIVE_EOF) {
+            break;
+        }
+        if (rc != ARCHIVE_OK) {
+            throw ArchiveIOError(ArchiveErrorMessage(a, "archive_read_next_header"));
+        }
+
+        const char* path_cstr = archive_entry_pathname(entry);
+        std::string name = path_cstr ? path_cstr : "";
+
+        std::vector<std::uint8_t> data;
+        std::array<std::uint8_t, 8192> chunk{};
+        while (true) {
+            const la_ssize_t n = archive_read_data(a, chunk.data(), chunk.size());
+            if (n < 0) {
+                throw ArchiveIOError(ArchiveErrorMessage(a, ("archive_read_data(" + name + ")").c_str()));
+            }
+            if (n == 0) {
+                break;
+            }
+            data.insert(data.end(), chunk.begin(), chunk.begin() + n);
+        }
+
+        result.emplace(std::move(name), std::move(data));
+    }
+
+    return result;
+}
+
+}  // namespace flapi

--- a/src/include/archive_io.hpp
+++ b/src/include/archive_io.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace flapi {
+
+using ArchiveEntries = std::map<std::string, std::vector<std::uint8_t>>;
+
+struct ArchiveWriteOptions {
+    std::optional<std::int64_t> source_date_epoch;
+};
+
+class ArchiveIOError : public std::runtime_error {
+public:
+    explicit ArchiveIOError(const std::string& message)
+        : std::runtime_error(message) {}
+};
+
+// Writes the entries as an in-memory ZIP archive.
+//
+// Entries are emitted in std::map iteration order (sorted by key), so
+// callers that hand in the same logical contents get a byte-identical
+// output as long as `source_date_epoch` matches.
+//
+// Internally calls `archive_write_set_bytes_in_last_block(a, 1)` so
+// the output is free of the 10240-byte tar-block zero padding that
+// would otherwise confuse a downstream EOCD reverse scan -- a
+// requirement of the self-packaging use case.
+//
+// Throws ArchiveIOError on libarchive failure.
+std::vector<std::uint8_t> WriteArchive(const ArchiveEntries& entries,
+                                       const ArchiveWriteOptions& options = {});
+
+// Reads an in-memory ZIP archive. Throws ArchiveIOError when the
+// buffer is empty, not a recognised ZIP, or truncated.
+ArchiveEntries ReadArchive(const std::vector<std::uint8_t>& buffer);
+
+}  // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Catch2 3 REQUIRED)
 
 add_executable(flapi_tests
     main.cpp
+    archive_io_test.cpp
     audit_logger_test.cpp
     auth_middleware_test.cpp
     config_manager_test.cpp

--- a/test/cpp/archive_io_test.cpp
+++ b/test/cpp/archive_io_test.cpp
@@ -1,0 +1,115 @@
+#include <catch2/catch_test_macros.hpp>
+#include "archive_io.hpp"
+
+#include <cstdint>
+#include <vector>
+
+using namespace flapi;
+
+namespace {
+
+ArchiveEntries SampleEntries() {
+    ArchiveEntries entries;
+    entries["flapi.yaml"] = {'p', 'r', 'o', 'j', 'e', 'c', 't', '-', 'n', 'a', 'm', 'e', ':', ' ', 'x'};
+    entries["sqls/customers.sql"] = {'S', 'E', 'L', 'E', 'C', 'T', ' ', '1'};
+    entries["data/cities.csv"] = {'c', 'i', 't', 'y', '\n', 'B', 'e', 'r', 'l', 'i', 'n'};
+    return entries;
+}
+
+}  // namespace
+
+TEST_CASE("archive_io round-trip preserves entry contents", "[archive_io]") {
+    auto input = SampleEntries();
+
+    auto bytes = WriteArchive(input);
+    REQUIRE_FALSE(bytes.empty());
+
+    auto roundtripped = ReadArchive(bytes);
+    REQUIRE(roundtripped == input);
+}
+
+TEST_CASE("archive_io is reproducible with a fixed source-date-epoch", "[archive_io]") {
+    auto input = SampleEntries();
+
+    ArchiveWriteOptions opts;
+    opts.source_date_epoch = 1'700'000'000;
+
+    auto a = WriteArchive(input, opts);
+    auto b = WriteArchive(input, opts);
+
+    REQUIRE_FALSE(a.empty());
+    REQUIRE(a == b);
+}
+
+TEST_CASE("archive_io emits entries in deterministic (sorted) order", "[archive_io]") {
+    // Two maps with the same logical contents but different construction
+    // orders. std::map already sorts, so wire order is map-iteration order.
+    // We assert that's stable -- the contract callers will rely on.
+    ArchiveEntries first;
+    first["zeta"] = {1};
+    first["alpha"] = {2};
+    first["mike"] = {3};
+
+    ArchiveEntries second;
+    second["alpha"] = {2};
+    second["mike"] = {3};
+    second["zeta"] = {1};
+
+    ArchiveWriteOptions opts;
+    opts.source_date_epoch = 0;
+
+    auto a = WriteArchive(first, opts);
+    auto b = WriteArchive(second, opts);
+
+    REQUIRE_FALSE(a.empty());
+    REQUIRE(a == b);
+}
+
+TEST_CASE("archive_io rejects malformed input without crashing", "[archive_io]") {
+    SECTION("empty buffer throws ArchiveIOError") {
+        std::vector<uint8_t> empty;
+        REQUIRE_THROWS_AS(ReadArchive(empty), ArchiveIOError);
+    }
+
+    SECTION("random garbage throws ArchiveIOError") {
+        std::vector<uint8_t> garbage(256);
+        for (size_t i = 0; i < garbage.size(); ++i) {
+            garbage[i] = static_cast<uint8_t>((i * 37 + 11) & 0xff);
+        }
+        REQUIRE_THROWS_AS(ReadArchive(garbage), ArchiveIOError);
+    }
+
+    SECTION("truncated valid zip throws ArchiveIOError") {
+        auto bytes = WriteArchive(SampleEntries());
+        REQUIRE(bytes.size() > 16);
+        bytes.resize(bytes.size() / 2);
+        REQUIRE_THROWS_AS(ReadArchive(bytes), ArchiveIOError);
+    }
+}
+
+TEST_CASE("archive_io has no trailing tar-block padding", "[archive_io]") {
+    // The spike caught libarchive's default 10240-byte tar-block rounding
+    // confusing the EOCD scan. The contract here: the last 4 bytes of a
+    // freshly written archive contain either the EOCD signature or, at
+    // minimum, no extraneous trailing zero padding that pushes the EOCD
+    // record more than 22 bytes from EOF on a comment-less archive.
+    auto bytes = WriteArchive(SampleEntries());
+    REQUIRE(bytes.size() >= 22);
+
+    // Locate the EOCD signature (0x06054b50, little-endian) by reverse scan.
+    // For a comment-less archive, it should sit exactly 22 bytes from EOF.
+    const std::uint32_t kEocdSig = 0x06054b50;
+    auto eocd_offset_from_end = [&bytes]() -> size_t {
+        for (size_t back = 22; back <= bytes.size() && back < 22 + 65536; ++back) {
+            size_t i = bytes.size() - back;
+            std::uint32_t v = std::uint32_t(bytes[i])
+                            | (std::uint32_t(bytes[i + 1]) << 8)
+                            | (std::uint32_t(bytes[i + 2]) << 16)
+                            | (std::uint32_t(bytes[i + 3]) << 24);
+            if (v == kEocdSig) return back;
+        }
+        return 0;
+    }();
+
+    REQUIRE(eocd_offset_from_end == 22);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "dependencies": [
     "catch2",
     "crow",
+    "libarchive",
     "fmt",
     "jwt-cpp",
     "argparse",


### PR DESCRIPTION
Part of epic #40. First sub-issue of the self-packaging work.

## Summary

- Adds **libarchive** to vcpkg.json (vcpkg pulls it on next configure).
- New `src/include/archive_io.hpp` + `src/archive_io.cpp`: thin RAII
  C++ wrapper over libarchive's C API for ZIP read/write in memory.
- Tests in `test/cpp/archive_io_test.cpp`: 5 cases, 14 assertions.

## Why

This is the foundation every later self-packaging sub-issue
(#42–#50) builds on. Bundle locator (#42) needs a deterministic ZIP
writer to produce test fixtures; embedded file provider (#43) needs
the reader to decompress entries at startup; pack (#45) needs both.

Doing it as its own PR keeps each layer reviewable in isolation.

## What's inside the wrapper

| Function | Purpose |
|----------|---------|
| `WriteArchive(entries, opts)` | `ArchiveEntries` (= `std::map<path, bytes>`) → `std::vector<uint8_t>` ZIP. |
| `ReadArchive(buffer)` | Reverse: `std::vector<uint8_t>` → `ArchiveEntries`. |
| `ArchiveWriteOptions::source_date_epoch` | mtime stamp for reproducible builds. |
| `ArchiveIOError` | Thrown on libarchive failure (truncated / malformed input). |

Two design choices worth flagging:

1. **`archive_write_set_bytes_in_last_block(a, 1)`** — the spike
   caught that libarchive's default 10240-byte tar-block padding
   pushes the EOCD record away from EOF and breaks the reverse-scan
   locator (#42 will use). This wrapper bakes the fix in so callers
   can't accidentally re-introduce the padding.

2. **`std::map` for entries** — deterministic iteration order, which
   is half of reproducible builds. The other half is the
   `source_date_epoch` mtime stamp. Same input + same epoch ⇒
   byte-identical output (tested).

## Tests (red-then-green TDD)

| # | Test | What it asserts |
|---|------|-----------------|
| 1 | round-trip preserves entry contents | `Read(Write(x)) == x` |
| 2 | reproducible with fixed `source_date_epoch` | Two writes with same input + epoch → identical bytes |
| 3 | deterministic sort order | Two maps with same logical contents, different insertion order → identical bytes |
| 4 | rejects malformed input | empty buffer / random garbage / truncated zip → `ArchiveIOError` |
| 5 | no trailing tar-block padding | EOCD signature sits exactly 22 bytes from EOF (no padding past it) |

```
$ ctest -V -R "archive_io"
100% tests passed, 0 tests failed out of 5
Total Test time (real) =   3.75 sec
```

## Test plan

- [x] `make test` builds and passes the new tests on Linux x86_64.
- [x] Existing 65 Catch2 tests run; two pre-existing failures
      (`QueryExecutor type coverage`, `DuckDBResult RAII`) are
      AddressSanitizer leaks in DuckDB internals introduced by
      96806ac on main, unrelated to this PR.
- [ ] CI (Linux ARM64, macOS, Windows) — vcpkg fetches libarchive
      on first configure; existing builds will need to re-configure
      after merge.

## Files

- `vcpkg.json` — `+libarchive`
- `CMakeLists.txt` — `find_package(LibArchive)`, link
  `LibArchive::LibArchive`, add `archive_io.cpp` to `flapi-lib`
- `src/include/archive_io.hpp` — public API
- `src/archive_io.cpp` — implementation
- `test/cpp/archive_io_test.cpp` + `test/cpp/CMakeLists.txt` — tests

Closes #41. Part of #40.