### PR TITLE
feat(self-packaging #42): selfpath + bundle_locator (EOCD reverse scan)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ add_library(flapi-lib STATIC
     src/api_server.cpp
     src/archive_io.cpp
     src/audit_logger.cpp
+    src/bundle_locator.cpp
     src/auth_middleware.cpp
     src/cache_manager.cpp
     src/database_manager_cache_adapter.cpp
@@ -263,6 +264,7 @@ add_library(flapi-lib STATIC
     src/prepared_value_converter.cpp
     src/route_translator.cpp
     src/security_auditor.cpp
+    src/selfpath.cpp
     src/sql_parameter_classifier.cpp
     src/sql_template_processor.cpp
     src/sql_utils.cpp

--- a/src/bundle_locator.cpp
+++ b/src/bundle_locator.cpp
@@ -1,0 +1,147 @@
+#include "bundle_locator.hpp"
+#include "selfpath.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <system_error>
+#include <vector>
+
+namespace flapi {
+
+namespace {
+
+constexpr std::size_t kEocdRecordSize = 22;
+constexpr std::size_t kMaxCommentLen = 0xffffu;
+
+// We accept padding well in excess of the 10 KiB spike default; the
+// total tail buffer is EOCD + max comment + 64 KiB pad budget.
+constexpr std::size_t kPaddingBudget = 65536;
+constexpr std::size_t kScanBudget = kEocdRecordSize + kMaxCommentLen + kPaddingBudget;
+
+std::uint16_t ReadU16(const std::uint8_t* p) {
+    return static_cast<std::uint16_t>(
+        static_cast<std::uint16_t>(p[0]) |
+        (static_cast<std::uint16_t>(p[1]) << 8));
+}
+
+std::uint32_t ReadU32(const std::uint8_t* p) {
+    return static_cast<std::uint32_t>(p[0])
+         | (static_cast<std::uint32_t>(p[1]) << 8)
+         | (static_cast<std::uint32_t>(p[2]) << 16)
+         | (static_cast<std::uint32_t>(p[3]) << 24);
+}
+
+}  // namespace
+
+std::optional<BundleLocation> LocateBundle(const std::filesystem::path& path) {
+    std::error_code ec;
+    const auto file_size = std::filesystem::file_size(path, ec);
+    if (ec || file_size < kEocdRecordSize) {
+        return std::nullopt;
+    }
+
+    std::ifstream in(path, std::ios::binary);
+    if (!in.is_open()) {
+        return std::nullopt;
+    }
+
+    const std::size_t tail_bytes =
+        static_cast<std::size_t>(std::min<std::uint64_t>(file_size, kScanBudget));
+    const std::uint64_t tail_start = file_size - tail_bytes;
+
+    std::vector<std::uint8_t> tail(tail_bytes);
+    in.seekg(static_cast<std::streamoff>(tail_start), std::ios::beg);
+    in.read(reinterpret_cast<char*>(tail.data()),
+            static_cast<std::streamsize>(tail_bytes));
+    if (!in) {
+        return std::nullopt;
+    }
+    if (tail.size() < kEocdRecordSize) {
+        return std::nullopt;
+    }
+
+    // Reverse-scan from the latest valid signature position. The latest
+    // (largest-offset) EOCD wins, since any earlier signature byte
+    // sequence in random leading data is a false positive.
+    const std::size_t max_start = tail.size() - kEocdRecordSize;
+    for (std::size_t i = max_start + 1; i-- > 0; ) {
+        if (tail[i]     != 0x50 ||
+            tail[i + 1] != 0x4b ||
+            tail[i + 2] != 0x05 ||
+            tail[i + 3] != 0x06) {
+            continue;
+        }
+
+        const std::uint8_t* p = tail.data() + i;
+        const std::uint16_t this_disk        = ReadU16(p + 4);
+        const std::uint16_t cd_start_disk    = ReadU16(p + 6);
+        const std::uint16_t entries_this     = ReadU16(p + 8);
+        const std::uint16_t entries_total    = ReadU16(p + 10);
+        const std::uint32_t cd_size          = ReadU32(p + 12);
+        const std::uint32_t cd_offset_arch   = ReadU32(p + 16);
+        const std::uint16_t comment_len      = ReadU16(p + 20);
+
+        // Multi-disk archives are not supported.
+        if (this_disk != 0 || cd_start_disk != 0) {
+            continue;
+        }
+        if (entries_this != entries_total) {
+            continue;
+        }
+
+        // The comment must fit in the tail.
+        const std::size_t comment_end = i + kEocdRecordSize + comment_len;
+        if (comment_end > tail.size()) {
+            continue;
+        }
+
+        // Anything after the comment up to file-EOF must be zero
+        // padding -- the libarchive tar-block rounding tolerance.
+        bool padding_ok = true;
+        for (std::size_t j = comment_end; j < tail.size(); ++j) {
+            if (tail[j] != 0) {
+                padding_ok = false;
+                break;
+            }
+        }
+        if (!padding_ok) {
+            continue;
+        }
+
+        const std::uint64_t eocd_file_offset = tail_start + i;
+
+        // The central directory sits immediately before the EOCD.
+        if (cd_size > eocd_file_offset) {
+            continue;
+        }
+        const std::uint64_t cd_file_offset = eocd_file_offset - cd_size;
+
+        if (cd_offset_arch > cd_file_offset) {
+            continue;
+        }
+        const std::uint64_t bundle_start = cd_file_offset - cd_offset_arch;
+
+        const std::uint64_t bundle_end = eocd_file_offset + kEocdRecordSize + comment_len;
+        if (bundle_end < bundle_start) {
+            continue;  // overflow paranoia
+        }
+
+        BundleLocation loc;
+        loc.offset = bundle_start;
+        loc.size = bundle_end - bundle_start;
+        return loc;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<BundleLocation> LocateBundleInSelf() {
+    try {
+        return LocateBundle(GetSelfPath());
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+}  // namespace flapi

--- a/src/include/bundle_locator.hpp
+++ b/src/include/bundle_locator.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+namespace flapi {
+
+// Location of an appended ZIP archive within a host binary.
+//
+// `offset` is the file offset of the first ZIP local file header --
+// the byte you would seek to when slicing the file for libarchive.
+// `size`   is the total bytes from `offset` through (and including)
+// the End-of-Central-Directory record plus its comment, excluding any
+// trailing zero padding that the locator tolerates.
+struct BundleLocation {
+    std::uint64_t offset = 0;
+    std::uint64_t size = 0;
+};
+
+// Reverse-scans the file at `path` for a ZIP End-of-Central-Directory
+// record. Returns the bundle's location, or nullopt if no valid
+// bundle is detected.
+//
+// Tolerates trailing zero padding after the EOCD record -- the
+// spike-caught case of libarchive's default 10240-byte tar-block
+// rounding pushing the EOCD off file-EOF.
+std::optional<BundleLocation> LocateBundle(const std::filesystem::path& path);
+
+// Convenience: scan the currently running executable. Returns nullopt
+// if either the self-path lookup or the EOCD scan fails.
+std::optional<BundleLocation> LocateBundleInSelf();
+
+}  // namespace flapi

--- a/src/include/selfpath.hpp
+++ b/src/include/selfpath.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <filesystem>
+
+namespace flapi {
+
+// Returns the absolute path of the currently running executable.
+// Implemented per-OS:
+//   - Linux:   readlink("/proc/self/exe")
+//   - macOS:   _NSGetExecutablePath
+//   - Windows: GetModuleFileNameW
+// Throws std::system_error on resolution failure.
+std::filesystem::path GetSelfPath();
+
+}  // namespace flapi

--- a/src/selfpath.cpp
+++ b/src/selfpath.cpp
@@ -1,0 +1,61 @@
+#include "selfpath.hpp"
+
+#include <cerrno>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+#elif defined(__APPLE__)
+    #include <mach-o/dyld.h>
+    #include <cstdint>
+#else
+    #include <unistd.h>
+#endif
+
+namespace flapi {
+
+std::filesystem::path GetSelfPath() {
+#ifdef _WIN32
+    std::vector<wchar_t> buf(MAX_PATH);
+    while (true) {
+        const DWORD n = GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
+        if (n == 0) {
+            throw std::system_error(static_cast<int>(GetLastError()), std::system_category(),
+                                    "GetModuleFileNameW failed");
+        }
+        if (n < buf.size()) {
+            return std::filesystem::path(std::wstring(buf.data(), n));
+        }
+        // Buffer too small (MS docs say n == buf.size() means truncated on
+        // older Windows; on newer it sets ERROR_INSUFFICIENT_BUFFER).
+        buf.resize(buf.size() * 2);
+    }
+#elif defined(__APPLE__)
+    std::uint32_t size = 0;
+    // First call sizes the buffer.
+    _NSGetExecutablePath(nullptr, &size);
+    std::vector<char> buf(size);
+    if (_NSGetExecutablePath(buf.data(), &size) != 0) {
+        throw std::system_error(errno, std::generic_category(),
+                                "_NSGetExecutablePath failed");
+    }
+    std::error_code ec;
+    auto canonical = std::filesystem::canonical(std::filesystem::path(buf.data()), ec);
+    if (ec) {
+        return std::filesystem::path(buf.data());
+    }
+    return canonical;
+#else
+    std::error_code ec;
+    auto resolved = std::filesystem::read_symlink("/proc/self/exe", ec);
+    if (ec) {
+        throw std::system_error(ec, "read_symlink(/proc/self/exe) failed");
+    }
+    return resolved;
+#endif
+}
+
+}  // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(flapi_tests
     main.cpp
     archive_io_test.cpp
     audit_logger_test.cpp
+    bundle_locator_test.cpp
     auth_middleware_test.cpp
     config_manager_test.cpp
     config_manager_yaml_validation_test.cpp

--- a/test/cpp/bundle_locator_test.cpp
+++ b/test/cpp/bundle_locator_test.cpp
@@ -1,0 +1,181 @@
+#include <catch2/catch_test_macros.hpp>
+#include "archive_io.hpp"
+#include "bundle_locator.hpp"
+#include "selfpath.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <vector>
+
+using namespace flapi;
+
+namespace {
+
+class TempBinary {
+public:
+    explicit TempBinary(const std::vector<std::uint8_t>& bytes) {
+        path_ = std::filesystem::temp_directory_path() /
+                ("bundle_locator_test_" +
+                 std::to_string(reinterpret_cast<std::uintptr_t>(this)) + ".bin");
+        std::ofstream f(path_, std::ios::binary);
+        if (!bytes.empty()) {
+            f.write(reinterpret_cast<const char*>(bytes.data()),
+                    static_cast<std::streamsize>(bytes.size()));
+        }
+    }
+    ~TempBinary() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+    TempBinary(const TempBinary&) = delete;
+    TempBinary& operator=(const TempBinary&) = delete;
+
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
+std::vector<std::uint8_t> RandomBytes(std::size_t n, std::uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::vector<std::uint8_t> bytes(n);
+    for (auto& b : bytes) {
+        b = static_cast<std::uint8_t>(rng() & 0xff);
+    }
+    return bytes;
+}
+
+std::vector<std::uint8_t> SampleZip() {
+    ArchiveEntries entries;
+    entries["flapi.yaml"] = {'p', 'r', 'o', 'j', 'e', 'c', 't'};
+    entries["sqls/customers.sql"] = {'S', 'E', 'L', 'E', 'C', 'T'};
+    entries["data/cities.csv"] = {'B', 'e', 'r', 'l', 'i', 'n'};
+
+    ArchiveWriteOptions opts;
+    opts.source_date_epoch = 1'700'000'000;
+    return WriteArchive(entries, opts);
+}
+
+void Append(std::vector<std::uint8_t>& dst, const std::vector<std::uint8_t>& src) {
+    dst.insert(dst.end(), src.begin(), src.end());
+}
+
+// Removes any incidental occurrence of the EOCD signature in random bytes so
+// the "no bundle" test isn't undermined by a 1-in-4-billion lottery win.
+void ScrubEocdSignature(std::vector<std::uint8_t>& bytes) {
+    for (std::size_t i = 0; i + 3 < bytes.size(); ++i) {
+        if (bytes[i] == 0x50 && bytes[i + 1] == 0x4b &&
+            bytes[i + 2] == 0x05 && bytes[i + 3] == 0x06) {
+            bytes[i] = 0x00;
+        }
+    }
+}
+
+}  // namespace
+
+TEST_CASE("bundle_locator finds ZIP appended to random leading bytes", "[bundle_locator]") {
+    auto leading = RandomBytes(4096, 0xc0ffee01);
+    ScrubEocdSignature(leading);
+    auto zip = SampleZip();
+
+    std::vector<std::uint8_t> file_bytes = leading;
+    Append(file_bytes, zip);
+
+    TempBinary tb{file_bytes};
+    auto loc = LocateBundle(tb.path());
+
+    REQUIRE(loc.has_value());
+    REQUIRE(loc->offset == leading.size());
+    REQUIRE(loc->size == zip.size());
+}
+
+TEST_CASE("bundle_locator tolerates 10 KiB of trailing zero padding", "[bundle_locator]") {
+    auto leading = RandomBytes(2048, 0xbadcafe);
+    ScrubEocdSignature(leading);
+    auto zip = SampleZip();
+
+    std::vector<std::uint8_t> file_bytes = leading;
+    Append(file_bytes, zip);
+    file_bytes.insert(file_bytes.end(), 10240, std::uint8_t{0});
+
+    TempBinary tb{file_bytes};
+    auto loc = LocateBundle(tb.path());
+
+    REQUIRE(loc.has_value());
+    REQUIRE(loc->offset == leading.size());
+    REQUIRE(loc->size == zip.size());
+}
+
+TEST_CASE("bundle_locator returns nullopt when no EOCD signature is present",
+          "[bundle_locator]") {
+    auto bytes = RandomBytes(8192, 0xdecafbad);
+    ScrubEocdSignature(bytes);
+
+    TempBinary tb{bytes};
+    auto loc = LocateBundle(tb.path());
+
+    REQUIRE_FALSE(loc.has_value());
+}
+
+TEST_CASE("bundle_locator rejects an EOCD with implausible fields", "[bundle_locator]") {
+    // 2 KiB of filler with a fake EOCD signature at the very end whose
+    // central-directory size/offset can't possibly fit in the file.
+    std::vector<std::uint8_t> bytes(2048, std::uint8_t{0xab});
+    const std::size_t eocd_off = bytes.size() - 22;
+
+    auto put_u16 = [&](std::size_t off, std::uint16_t v) {
+        bytes[off] = static_cast<std::uint8_t>(v & 0xff);
+        bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
+    };
+    auto put_u32 = [&](std::size_t off, std::uint32_t v) {
+        bytes[off]     = static_cast<std::uint8_t>(v & 0xff);
+        bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
+        bytes[off + 2] = static_cast<std::uint8_t>((v >> 16) & 0xff);
+        bytes[off + 3] = static_cast<std::uint8_t>((v >> 24) & 0xff);
+    };
+
+    put_u32(eocd_off + 0, 0x06054b50);   // signature
+    put_u16(eocd_off + 4, 0);             // disk number
+    put_u16(eocd_off + 6, 0);             // disk where CD starts
+    put_u16(eocd_off + 8, 1);             // entries on this disk
+    put_u16(eocd_off + 10, 1);            // total entries
+    put_u32(eocd_off + 12, 0xffffffffu);  // central directory size
+    put_u32(eocd_off + 16, 0xffffffffu);  // central directory offset
+    put_u16(eocd_off + 20, 0);            // comment length
+
+    TempBinary tb{bytes};
+    auto loc = LocateBundle(tb.path());
+    REQUIRE_FALSE(loc.has_value());
+}
+
+TEST_CASE("bundle_locator returns nullopt for a truncated bundle", "[bundle_locator]") {
+    auto leading = RandomBytes(2048, 0xfeedbeef);
+    ScrubEocdSignature(leading);
+    auto zip = SampleZip();
+
+    std::vector<std::uint8_t> file_bytes = leading;
+    Append(file_bytes, zip);
+
+    REQUIRE(file_bytes.size() > 1024);
+    file_bytes.resize(file_bytes.size() - 1024);  // chop EOCD off the tail
+
+    TempBinary tb{file_bytes};
+    auto loc = LocateBundle(tb.path());
+    REQUIRE_FALSE(loc.has_value());
+}
+
+TEST_CASE("selfpath returns an existing executable path", "[selfpath]") {
+    auto path = GetSelfPath();
+
+    REQUIRE_FALSE(path.empty());
+    REQUIRE(std::filesystem::exists(path));
+}
+
+TEST_CASE("LocateBundleInSelf returns nullopt when no bundle is present",
+          "[bundle_locator]") {
+    // The test binary itself has no appended ZIP, so this should be nullopt.
+    auto loc = LocateBundleInSelf();
+    REQUIRE_FALSE(loc.has_value());
+}


### PR DESCRIPTION
Part of epic #40. **Depends on #51** (sets the base branch -- once #51 lands, GitHub will offer a one-click rebase onto main).

## Summary

Two small modules that together let the running binary discover whether
a ZIP archive has been appended to it.

- `src/selfpath.{hpp,cpp}` -- cross-platform self-binary path
  (`/proc/self/exe` / `_NSGetExecutablePath` / `GetModuleFileNameW`).
- `src/bundle_locator.{hpp,cpp}` -- reverse-scan a file for a ZIP
  End-of-Central-Directory record, returning `BundleLocation{offset, size}`
  or `nullopt`.

## Why

This is the runtime-detection half of self-packaging. The next sub-issue
(#43, `EmbeddedArchiveFileProvider`) calls `LocateBundleInSelf()` once
at startup; if it returns a location, the bytes at that range are fed to
`archive_io::ReadArchive` (PR #51) and become the in-memory config tree.

## What the locator checks

| Check | Rejected as | Why |
|-------|-------------|-----|
| EOCD signature `0x06054b50` not present in tail | nullopt | obviously no ZIP |
| multi-disk archive | nullopt | not a single-binary use case |
| `entries_this != entries_total` | nullopt | inconsistent record |
| comment length doesn't fit in scanned tail | nullopt | record claims more than file has |
| bytes after EOCD+comment are non-zero | nullopt | not a clean append |
| central dir doesn't fit before EOCD | nullopt | impossible layout |
| central dir offset > file central dir offset | nullopt | overflow / corruption |

**The padding tolerance is the load-bearing bit.** The spike caught
libarchive's default 10240-byte tar-block rounding pushing the EOCD off
file-EOF. We scan a tail of `22 + 65535 + 65536` bytes and accept any
amount of zero padding after the EOCD+comment, up to that budget.
PR #51 already neutralises this on the writer side via
`archive_write_set_bytes_in_last_block(a, 1)`, but the reader is
defensive too.

## How `BundleLocation` is computed

ZIP layout in the file:

```
[leading host binary bytes][local file headers][central dir][EOCD][trailing pad]
                          ^                                ^
                          bundle_start                     eocd_file_offset
```

```
bundle_start = eocd_file_offset - cd_size - cd_offset_in_archive
bundle_end   = eocd_file_offset + 22 + comment_length
loc.offset   = bundle_start
loc.size     = bundle_end - bundle_start
```

So `loc.offset` is the byte you `seek()` to, and `loc.size` is what you
read -- the result is a valid standalone ZIP that `ReadArchive` can
parse directly without any libarchive offset-shifting magic.

## Tests (red-then-green TDD)

| # | Test | What it asserts |
|---|------|-----------------|
| 1 | locate appended ZIP | 4 KiB random + ZIP → `offset == 4096`, `size == zip.size()` |
| 2 | padding tolerance | + 10240 zeros → still located at same offset |
| 3 | no signature | random bytes, scrubbed → `nullopt` |
| 4 | malformed EOCD | fake sig at EOF with `cd_size = 0xffffffff` → `nullopt` |
| 5 | truncation | append valid ZIP, lop 1 KiB → `nullopt` |
| 6 | `GetSelfPath` | returns existing path |
| 7 | `LocateBundleInSelf` | unbundled test binary → `nullopt` |

```
7/7 Test #19: LocateBundleInSelf returns nullopt when no bundle is present_test  Passed
100% tests passed, 0 tests failed out of 7
```

Fixtures reuse `archive_io::WriteArchive` from #51 -- so the locator is
tested against real libarchive output, not synthetic ZIPs.

## Test plan

- [x] All 7 new tests pass.
- [x] Existing 590 tests still pass; the same 2 pre-existing
      AddressSanitizer leaks in DuckDB internals (`QueryExecutor type
      coverage`, `DuckDBResult RAII`) from 96806ac on main remain.
- [ ] CI cross-platform once stacked PRs land.

Closes #42. Part of #40. Stacked on #51.