### PR TITLE
feat(self-packaging #43): EmbeddedArchiveFileProvider + factory dispatch + startup wire-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ add_library(flapi-lib STATIC
     src/config_service.cpp
     src/cors_middleware.cpp
     src/cors_policy.cpp
+    src/embedded_archive_file_provider.cpp
     src/database_manager.cpp
     src/endpoint_config_parser.cpp
     src/extended_yaml_parser.cpp

--- a/src/embedded_archive_file_provider.cpp
+++ b/src/embedded_archive_file_provider.cpp
@@ -1,0 +1,131 @@
+#include "embedded_archive_file_provider.hpp"
+
+#include <algorithm>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+namespace flapi {
+
+namespace {
+
+constexpr const char* kFileScheme = "file://";
+
+std::string NormaliseKey(const std::string& path) {
+    std::string s = path;
+
+    // Strip file:// prefix.
+    if (s.rfind(kFileScheme, 0) == 0) {
+        s.erase(0, std::string(kFileScheme).size());
+    }
+
+    // Strip leading "./" repeatedly.
+    while (s.size() >= 2 && s[0] == '.' && s[1] == '/') {
+        s.erase(0, 2);
+    }
+
+    // Strip a single leading slash. Embedded entries are always relative
+    // to the bundle root, never absolute.
+    if (!s.empty() && s.front() == '/') {
+        s.erase(0, 1);
+    }
+
+    return s;
+}
+
+std::string NormaliseDirectory(const std::string& directory) {
+    std::string s = NormaliseKey(directory);
+    while (!s.empty() && s.back() == '/') {
+        s.pop_back();
+    }
+    return s;
+}
+
+std::regex GlobToRegex(const std::string& pattern) {
+    std::string out;
+    out.reserve(pattern.size() * 2);
+    for (char c : pattern) {
+        switch (c) {
+            case '*':
+                out += ".*";
+                break;
+            case '?':
+                out += '.';
+                break;
+            case '.': case '+': case '^': case '$':
+            case '(': case ')': case '[': case ']':
+            case '{': case '}': case '|': case '\\':
+                out += '\\';
+                out += c;
+                break;
+            default:
+                out += c;
+                break;
+        }
+    }
+    return std::regex(out, std::regex::icase);
+}
+
+}  // namespace
+
+EmbeddedArchiveFileProvider::EmbeddedArchiveFileProvider(
+        std::shared_ptr<const ArchiveEntries> entries)
+    : _entries(std::move(entries)) {
+    if (_entries == nullptr) {
+        throw std::invalid_argument(
+            "EmbeddedArchiveFileProvider requires non-null ArchiveEntries");
+    }
+}
+
+std::string EmbeddedArchiveFileProvider::ReadFile(const std::string& path) {
+    const auto key = NormaliseKey(path);
+    auto it = _entries->find(key);
+    if (it == _entries->end()) {
+        throw FileOperationError("Embedded bundle has no entry: " + path);
+    }
+    const auto& data = it->second;
+    return std::string(reinterpret_cast<const char*>(data.data()), data.size());
+}
+
+bool EmbeddedArchiveFileProvider::FileExists(const std::string& path) {
+    const auto key = NormaliseKey(path);
+    return _entries->find(key) != _entries->end();
+}
+
+std::vector<std::string> EmbeddedArchiveFileProvider::ListFiles(
+        const std::string& directory, const std::string& pattern) {
+    const auto dir = NormaliseDirectory(directory);
+    const std::string prefix = dir.empty() ? "" : dir + "/";
+
+    std::vector<std::string> result;
+    std::regex name_re = GlobToRegex(pattern);
+
+    for (const auto& [name, _data] : *_entries) {
+        if (!prefix.empty()) {
+            if (name.rfind(prefix, 0) != 0) {
+                continue;
+            }
+        }
+        const auto remainder = name.substr(prefix.size());
+        // Skip nested subdirectory entries -- ListFiles is non-recursive
+        // to mirror LocalFileProvider's directory_iterator semantics.
+        if (remainder.find('/') != std::string::npos) {
+            continue;
+        }
+        if (remainder.empty()) {
+            continue;
+        }
+        if (std::regex_match(remainder, name_re)) {
+            result.push_back(name);
+        }
+    }
+
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+bool EmbeddedArchiveFileProvider::IsRemotePath(const std::string& /*path*/) const {
+    return false;
+}
+
+}  // namespace flapi

--- a/src/include/embedded_archive_file_provider.hpp
+++ b/src/include/embedded_archive_file_provider.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "archive_io.hpp"
+#include "vfs_adapter.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace flapi {
+
+// IFileProvider implementation backed by a decompressed in-memory ZIP.
+//
+// Used when the running binary has a bundle appended (#42). Entries
+// live in a `std::shared_ptr<const ArchiveEntries>` shared with the
+// DuckDB-side `embed://` filesystem (#44) so we hold one in-memory map,
+// not two.
+//
+// Path normalisation rules (input -> entry key):
+//   - leading `file://` stripped (parity with LocalFileProvider)
+//   - leading `./` stripped, repeatedly
+//   - leading `/` stripped
+//   - trailing `/` stripped on directories
+class EmbeddedArchiveFileProvider : public IFileProvider {
+public:
+    explicit EmbeddedArchiveFileProvider(std::shared_ptr<const ArchiveEntries> entries);
+    ~EmbeddedArchiveFileProvider() override = default;
+
+    std::string ReadFile(const std::string& path) override;
+    bool FileExists(const std::string& path) override;
+    std::vector<std::string> ListFiles(const std::string& directory,
+                                       const std::string& pattern = "*") override;
+    bool IsRemotePath(const std::string& path) const override;
+    std::string GetProviderName() const override { return "embedded"; }
+
+private:
+    std::shared_ptr<const ArchiveEntries> _entries;
+};
+
+}  // namespace flapi

--- a/src/include/vfs_adapter.hpp
+++ b/src/include/vfs_adapter.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace flapi {
+
+// Forward-declared so the factory can refer to bundle contents without
+// pulling in the archive_io.hpp dependency.
+using ArchiveEntries = std::map<std::string, std::vector<std::uint8_t>>;
 
 /**
  * Exception thrown when a file operation fails.
@@ -22,7 +28,8 @@ public:
  *
  * Implementations:
  * - LocalFileProvider: Standard filesystem operations (std::filesystem)
- * - DuckDBVFSProvider: DuckDB's VFS for S3, GCS, Azure, HTTP (future)
+ * - DuckDBVFSProvider: DuckDB's VFS for S3, GCS, Azure, HTTP
+ * - EmbeddedArchiveFileProvider: in-memory ZIP appended to the binary
  */
 class IFileProvider {
 public:
@@ -208,11 +215,12 @@ class FileProviderFactory {
 public:
     /**
      * Create an appropriate file provider for the given path.
-     * Returns LocalFileProvider for local paths (no scheme or file://).
-     * Returns DuckDBVFSProvider for remote paths (s3://, gs://, az://, http://, https://).
      *
-     * @param path Path to create provider for (used to detect scheme)
-     * @return Shared pointer to appropriate file provider
+     * Dispatch order:
+     *   1. Remote schemes (s3://, gs://, az://, http(s)://) -> DuckDBVFSProvider
+     *   2. Process has a bundle set via SetBundleContents() -> EmbeddedArchiveFileProvider
+     *   3. Otherwise -> LocalFileProvider
+     *
      * @throws FileOperationError if remote path requested but DatabaseManager not initialized
      */
     static std::shared_ptr<IFileProvider> CreateProvider(const std::string& path);
@@ -229,6 +237,27 @@ public:
      * @throws FileOperationError if DatabaseManager is not initialized
      */
     static std::shared_ptr<IFileProvider> CreateDuckDBProvider();
+
+    /**
+     * Create an embedded provider backed by the currently set bundle.
+     * @throws FileOperationError if no bundle is currently set.
+     */
+    static std::shared_ptr<IFileProvider> CreateEmbeddedProvider();
+
+    /**
+     * Set the process-wide ZIP-bundle contents that CreateProvider() and
+     * CreateEmbeddedProvider() consult. Pass nullptr to clear.
+     *
+     * Called once at startup by main() after `LocateBundleInSelf()`
+     * succeeds. Tests should pair set/clear with an RAII guard to keep
+     * the static clean.
+     */
+    static void SetBundleContents(std::shared_ptr<const ArchiveEntries> entries);
+
+    /**
+     * Returns the currently set bundle contents, or nullptr if none.
+     */
+    static std::shared_ptr<const ArchiveEntries> GetBundleContents();
 };
 
 } // namespace flapi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,9 @@
 #endif
 
 #include "api_server.hpp"
+#include "archive_io.hpp"
 #include "auth_middleware.hpp"
+#include "bundle_locator.hpp"
 #include "config_manager.hpp"
 #include "database_manager.hpp"
 #include "flapi_telemetry.hpp"
@@ -25,6 +27,8 @@
 #include "config_token_utils.hpp"
 #include "credential_manager.hpp"
 #include "security_auditor.hpp"
+#include "selfpath.hpp"
+#include "vfs_adapter.hpp"
 #include "vfs_health_checker.hpp"
 
 using namespace flapi;
@@ -57,6 +61,45 @@ std::shared_ptr<ConfigManager> initializeConfig(const std::string& config_file) 
         throw std::runtime_error("Error while loading configuration, Details: " + std::string(e.what()));
     }
     return config_manager;
+}
+
+// Detects whether the running binary has a ZIP bundle appended to it and,
+// if so, decompresses it once and hands it to FileProviderFactory so all
+// later config / SQL-template reads come from the in-memory map.
+// Failure to read or decompress is logged at WARNING and silently falls
+// back to filesystem mode -- the spike's safety-net behaviour (#42).
+void detectAndRegisterEmbeddedBundle() {
+    auto loc = LocateBundleInSelf();
+    if (!loc.has_value()) {
+        return;
+    }
+
+    try {
+        const auto self_path = GetSelfPath();
+        std::ifstream f(self_path, std::ios::binary);
+        if (!f.is_open()) {
+            CROW_LOG_WARNING << "Bundle detected but self-binary unreadable; "
+                                "falling back to filesystem mode";
+            return;
+        }
+
+        std::vector<std::uint8_t> bytes(loc->size);
+        f.seekg(static_cast<std::streamoff>(loc->offset), std::ios::beg);
+        f.read(reinterpret_cast<char*>(bytes.data()),
+               static_cast<std::streamsize>(loc->size));
+        if (!f) {
+            CROW_LOG_WARNING << "Bundle read truncated; falling back to filesystem mode";
+            return;
+        }
+
+        auto entries = std::make_shared<ArchiveEntries>(ReadArchive(bytes));
+        const std::size_t entry_count = entries->size();
+        FileProviderFactory::SetBundleContents(std::move(entries));
+        CROW_LOG_INFO << "Bundle detected and registered (" << entry_count << " entries)";
+    } catch (const std::exception& e) {
+        CROW_LOG_WARNING << "Bundle detection failed (" << e.what()
+                         << "); falling back to filesystem mode";
+    }
 }
 
 std::string getEndpointName(const EndpointConfig& endpoint) {
@@ -331,6 +374,8 @@ int main(int argc, char* argv[])
     }
 
     set_log_level(log_level);
+
+    detectAndRegisterEmbeddedBundle();
 
     auto config_manager = initializeConfig(config_file);
 

--- a/src/vfs_adapter.cpp
+++ b/src/vfs_adapter.cpp
@@ -1,4 +1,7 @@
 #include "vfs_adapter.hpp"
+
+#include "embedded_archive_file_provider.hpp"
+
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -400,9 +403,21 @@ bool DuckDBVFSProvider::IsRemotePath(const std::string& path) const {
 // FileProviderFactory Implementation
 // ============================================================================
 
+namespace {
+
+// Process-wide bundle contents pointer. Set once by main() after
+// LocateBundleInSelf() succeeds; nullptr means filesystem-mode is
+// active.
+std::shared_ptr<const ArchiveEntries> g_bundle_entries;
+
+}  // namespace
+
 std::shared_ptr<IFileProvider> FileProviderFactory::CreateProvider(const std::string& path) {
     if (PathSchemeUtils::IsRemotePath(path)) {
         return CreateDuckDBProvider();
+    }
+    if (g_bundle_entries != nullptr) {
+        return CreateEmbeddedProvider();
     }
     return CreateLocalProvider();
 }
@@ -413,6 +428,22 @@ std::shared_ptr<IFileProvider> FileProviderFactory::CreateLocalProvider() {
 
 std::shared_ptr<IFileProvider> FileProviderFactory::CreateDuckDBProvider() {
     return std::make_shared<DuckDBVFSProvider>();
+}
+
+std::shared_ptr<IFileProvider> FileProviderFactory::CreateEmbeddedProvider() {
+    if (g_bundle_entries == nullptr) {
+        throw FileOperationError(
+            "Cannot create embedded provider: no bundle is currently set");
+    }
+    return std::make_shared<EmbeddedArchiveFileProvider>(g_bundle_entries);
+}
+
+void FileProviderFactory::SetBundleContents(std::shared_ptr<const ArchiveEntries> entries) {
+    g_bundle_entries = std::move(entries);
+}
+
+std::shared_ptr<const ArchiveEntries> FileProviderFactory::GetBundleContents() {
+    return g_bundle_entries;
 }
 
 } // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(flapi_tests
     config_service_schema_test.cpp
     config_tool_adapter_test.cpp
     database_manager_test.cpp
+    embedded_archive_file_provider_test.cpp
     endpoint_config_parser_test.cpp
     extended_yaml_parser_test.cpp
     https_config_test.cpp

--- a/test/cpp/embedded_archive_file_provider_test.cpp
+++ b/test/cpp/embedded_archive_file_provider_test.cpp
@@ -1,0 +1,155 @@
+#include <catch2/catch_test_macros.hpp>
+#include "archive_io.hpp"
+#include "embedded_archive_file_provider.hpp"
+#include "vfs_adapter.hpp"
+
+#include <algorithm>
+#include <memory>
+
+using namespace flapi;
+
+namespace {
+
+std::shared_ptr<const ArchiveEntries> SampleEntries() {
+    auto entries = std::make_shared<ArchiveEntries>();
+    (*entries)["flapi.yaml"] =
+        {'p', 'r', 'o', 'j', 'e', 'c', 't', '-', 'n', 'a', 'm', 'e'};
+    (*entries)["sqls/customers.yaml"] = {'c', 'y'};
+    (*entries)["sqls/customers.sql"] = {'S', 'E', 'L', 'E', 'C', 'T'};
+    (*entries)["sqls/orders.yaml"] = {'o', 'y'};
+    (*entries)["sqls/orders.sql"] = {'I', 'N', 'S', 'E', 'R', 'T'};
+    (*entries)["data/cities.csv"] = {'B', 'e', 'r', 'l', 'i', 'n'};
+    return entries;
+}
+
+// RAII guard so factory-dispatch tests can't leak global state.
+struct BundleGuard {
+    explicit BundleGuard(std::shared_ptr<const ArchiveEntries> e) {
+        FileProviderFactory::SetBundleContents(std::move(e));
+    }
+    ~BundleGuard() { FileProviderFactory::SetBundleContents(nullptr); }
+    BundleGuard(const BundleGuard&) = delete;
+    BundleGuard& operator=(const BundleGuard&) = delete;
+};
+
+}  // namespace
+
+TEST_CASE("EmbeddedArchiveFileProvider returns bytes for a known entry",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE(provider.ReadFile("sqls/customers.sql") == "SELECT");
+    REQUIRE(provider.ReadFile("data/cities.csv") == "Berlin");
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider normalises ./ and file:// prefixes",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE(provider.ReadFile("./flapi.yaml") == "project-name");
+    REQUIRE(provider.ReadFile("file://sqls/customers.sql") == "SELECT");
+    REQUIRE(provider.ReadFile("./sqls/orders.sql") == "INSERT");
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider throws on a missing entry",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE_THROWS_AS(provider.ReadFile("sqls/missing.sql"), FileOperationError);
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider::FileExists matches present and absent",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE(provider.FileExists("flapi.yaml"));
+    REQUIRE(provider.FileExists("./flapi.yaml"));
+    REQUIRE(provider.FileExists("sqls/customers.sql"));
+    REQUIRE_FALSE(provider.FileExists("sqls/missing.sql"));
+    REQUIRE_FALSE(provider.FileExists("nope/at/all.yaml"));
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider::ListFiles applies a glob pattern",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+
+    auto yamls = provider.ListFiles("sqls", "*.yaml");
+    REQUIRE(yamls.size() == 2);
+    REQUIRE(yamls[0] == "sqls/customers.yaml");
+    REQUIRE(yamls[1] == "sqls/orders.yaml");
+
+    auto sqls = provider.ListFiles("sqls", "*.sql");
+    REQUIRE(sqls.size() == 2);
+    REQUIRE(sqls[0] == "sqls/customers.sql");
+    REQUIRE(sqls[1] == "sqls/orders.sql");
+
+    auto all_in_sqls = provider.ListFiles("sqls", "*");
+    REQUIRE(all_in_sqls.size() == 4);
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider::ListFiles is non-recursive",
+          "[embedded_provider]") {
+    auto entries = std::make_shared<ArchiveEntries>();
+    (*entries)["sqls/a.sql"] = {};
+    (*entries)["sqls/sub/b.sql"] = {};
+    (*entries)["sqls/sub/c.sql"] = {};
+
+    EmbeddedArchiveFileProvider provider(entries);
+    auto list = provider.ListFiles("sqls", "*.sql");
+
+    REQUIRE(list.size() == 1);
+    REQUIRE(list[0] == "sqls/a.sql");
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider::IsRemotePath always returns false",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE_FALSE(provider.IsRemotePath("flapi.yaml"));
+    REQUIRE_FALSE(provider.IsRemotePath("s3://bucket/key"));
+}
+
+TEST_CASE("EmbeddedArchiveFileProvider::GetProviderName is 'embedded'",
+          "[embedded_provider]") {
+    EmbeddedArchiveFileProvider provider(SampleEntries());
+    REQUIRE(provider.GetProviderName() == "embedded");
+}
+
+TEST_CASE("FileProviderFactory picks EmbeddedArchiveFileProvider when a bundle is set",
+          "[vfs][factory][embedded_provider]") {
+    BundleGuard guard{SampleEntries()};
+
+    auto provider = FileProviderFactory::CreateProvider("flapi.yaml");
+    REQUIRE(provider != nullptr);
+    REQUIRE(provider->GetProviderName() == "embedded");
+
+    auto rel = FileProviderFactory::CreateProvider("sqls/customers.sql");
+    REQUIRE(rel != nullptr);
+    REQUIRE(rel->GetProviderName() == "embedded");
+}
+
+TEST_CASE("FileProviderFactory still picks the local provider when no bundle is set",
+          "[vfs][factory][embedded_provider]") {
+    // Defensive: clear any leakage from earlier tests.
+    FileProviderFactory::SetBundleContents(nullptr);
+
+    auto provider = FileProviderFactory::CreateProvider("/tmp/x.yaml");
+    REQUIRE(provider != nullptr);
+    REQUIRE(provider->GetProviderName() == "local");
+}
+
+TEST_CASE("FileProviderFactory routes remote paths to DuckDB even with a bundle",
+          "[vfs][factory][embedded_provider]") {
+    BundleGuard guard{SampleEntries()};
+
+    // DuckDBVFSProvider needs DatabaseManager. If a previous test
+    // initialised it, we should see "duckdb-vfs"; otherwise a
+    // FileOperationError mentioning the database is acceptable.
+    try {
+        auto provider = FileProviderFactory::CreateProvider("s3://bucket/key");
+        REQUIRE(provider != nullptr);
+        REQUIRE(provider->GetProviderName() == "duckdb-vfs");
+    } catch (const FileOperationError& e) {
+        const std::string msg(e.what());
+        const bool mentions_db =
+            msg.find("Database") != std::string::npos ||
+            msg.find("database") != std::string::npos ||
+            msg.find("initialized") != std::string::npos;
+        REQUIRE(mentions_db);
+    }
+}


### PR DESCRIPTION
Part of epic #40. **Stacked on #52** which is stacked on #51 -- once #51 and #52 merge, GitHub will retarget this to main.

## Summary

This is the runtime piece that makes a bundled binary actually serve bundled
content. After this PR, the only thing missing for a working
filesystem-or-bundle binary is the `flapi pack` subcommand to create the
bundle in the first place (#45) and the DuckDB-side `embed://` reader (#44).

- New `src/include/embedded_archive_file_provider.hpp` +
  `src/embedded_archive_file_provider.cpp` -- IFileProvider over a
  shared `ArchiveEntries`.
- `FileProviderFactory` learns about bundles via a process-wide static
  (`SetBundleContents` / `GetBundleContents` /
  `CreateEmbeddedProvider`).
- `main.cpp` adds `detectAndRegisterEmbeddedBundle()` that runs once
  after `set_log_level` and before `initializeConfig`.

## Dispatch order (the load-bearing change)

```
                       ┌── remote scheme? ──> DuckDBVFSProvider  (unchanged)
CreateProvider(path) ──┤
                       └── bundle present? ──> EmbeddedArchiveFileProvider  (new)
                            else            ──> LocalFileProvider          (unchanged)
```

Note that bundle never wins over remote -- `s3://` etc still flow to
DuckDB even with a bundle set. That's deliberate: bundled deploys still
need to access cloud data sources at query time.

## Why no churn in `config_loader` / `sql_template_processor`

The exploration in #40 confirmed both already accept any `IFileProvider`:

- `ConfigLoader` has an overload that takes a custom provider
  (`src/include/config_loader.hpp:37-38`).
- `SqlTemplateProcessor` already routes through
  `config_manager->getFileProvider()`
  (`src/sql_template_processor.cpp:69`).

So we change zero call sites. The factory dispatch is the only seam.

## Path normalisation

The embedded provider strips, in order:

1. `file://` scheme prefix (parity with LocalFileProvider).
2. Leading `./` (potentially repeated -- `././foo` -> `foo`).
3. Leading `/` (entries are always relative to the bundle root).

So all of `flapi.yaml`, `./flapi.yaml`, `file://flapi.yaml`, and
`/flapi.yaml` resolve to the bundle key `flapi.yaml`.

`ListFiles` is non-recursive on purpose -- `LocalFileProvider` uses
`directory_iterator` which doesn't descend, and we want behavioural
parity. Test case `ListFiles is non-recursive` enforces this.

## Startup wire-up

```cpp
void detectAndRegisterEmbeddedBundle() {
    auto loc = LocateBundleInSelf();          // #42
    if (!loc.has_value()) return;             // filesystem mode

    try {
        // Read slice [loc->offset, loc->offset + loc->size) from GetSelfPath()
        // ReadArchive(...)                   // #41
        // FileProviderFactory::SetBundleContents(entries);
    } catch (...) {
        // Log WARNING, fall back to filesystem mode (the spike safety net)
    }
}
```

Failure modes (unreadable binary, truncated slice, malformed ZIP) all
log at WARNING and silently fall back. Spike behaviour #7 (truncate 1 KiB
-> filesystem mode) was the test #42 PR #52 added, and the read-slice
path here honours it.

## Tests

11 new test cases in `test/cpp/embedded_archive_file_provider_test.cpp`:

| # | Test | What it asserts |
|---|------|-----------------|
| 1 | `ReadFile` on a known entry | bytes back unchanged |
| 2 | path normalisation | `./flapi.yaml`, `file://...`, `./sqls/...` all resolve |
| 3 | throws on missing entry | `FileOperationError` |
| 4 | `FileExists` present/absent | true/false |
| 5 | `ListFiles` with `*.yaml`, `*.sql`, `*` | correct results in sorted order |
| 6 | `ListFiles` non-recursive | nested `sub/b.sql` excluded |
| 7 | `IsRemotePath` always false | sanity |
| 8 | `GetProviderName == "embedded"` | sanity |
| 9 | factory picks embedded when bundle set | dispatch |
| 10 | factory falls back to local when no bundle | dispatch |
| 11 | factory routes `s3://` to DuckDB even with bundle | dispatch |

```
14/14 Test #143: FileProviderFactory routes remote paths to DuckDB even with a bundle_test  Passed
100% tests passed, 0 tests failed out of 14
```

Plus the 3 existing FileProviderFactory tests still pass unchanged.

## Test plan

- [x] 11 new tests pass; 14 total including existing factory tests.
- [x] All other Catch2 tests still pass; same 2 pre-existing DuckDB
      AddressSanitizer leaks (`QueryExecutor type coverage`,
      `DuckDBResult RAII`) on `main`.
- [x] Smoke: `flapi --validate-config -c examples/flapi.yaml` loads
      cleanly with no bundle messages (filesystem mode unchanged).
- [ ] CI cross-platform once stacked PRs land.

Closes #43. Part of #40. Stacked on #52, which is stacked on #51.