### PR TITLE
feat(self-packaging #44): embed:// DuckDB filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ add_library(flapi-lib STATIC
     src/auth_middleware.cpp
     src/cache_manager.cpp
     src/database_manager_cache_adapter.cpp
+    src/duckdb_embed_fs.cpp
     src/config_loader.cpp
     src/endpoint_repository.cpp
     src/config_validator.cpp

--- a/src/duckdb_embed_fs.cpp
+++ b/src/duckdb_embed_fs.cpp
@@ -1,0 +1,255 @@
+#include "duckdb_embed_fs.hpp"
+
+#include "database_manager.hpp"
+#include "vfs_adapter.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace flapi {
+
+namespace {
+
+// File handle holding a non-owning pointer to bytes in ArchiveEntries
+// plus a streaming position. The owning shared_ptr lives in the
+// EmbeddedFileSystem instance, so the data is valid as long as the
+// filesystem outlives all its handles -- guaranteed for DuckDB
+// sub-systems registered with RegisterSubSystem.
+class EmbeddedFileHandle : public ::duckdb::FileHandle {
+public:
+    EmbeddedFileHandle(EmbeddedFileSystem& fs,
+                       std::string path,
+                       ::duckdb::FileOpenFlags flags,
+                       const std::vector<std::uint8_t>* data)
+        : ::duckdb::FileHandle(fs, std::move(path), flags),
+          data_(data),
+          position_(0) {}
+
+    void Close() override { /* in-memory, nothing to release */ }
+
+    const std::vector<std::uint8_t>* data() const { return data_; }
+    ::duckdb::idx_t position() const { return position_; }
+    void set_position(::duckdb::idx_t p) { position_ = p; }
+
+private:
+    const std::vector<std::uint8_t>* data_;
+    ::duckdb::idx_t position_;
+};
+
+EmbeddedFileHandle& AsEmbedded(::duckdb::FileHandle& h) {
+    return h.Cast<EmbeddedFileHandle>();
+}
+
+bool HasEmbedScheme(const std::string& path) {
+    const std::size_t scheme_len = std::strlen(kEmbedScheme);
+    return path.size() >= scheme_len &&
+           path.compare(0, scheme_len, kEmbedScheme) == 0;
+}
+
+std::string StripEmbedScheme(const std::string& path) {
+    const std::size_t scheme_len = std::strlen(kEmbedScheme);
+    if (HasEmbedScheme(path)) {
+        return path.substr(scheme_len);
+    }
+    return path;
+}
+
+bool ContainsGlobMeta(const std::string& s) {
+    return s.find('*') != std::string::npos ||
+           s.find('?') != std::string::npos ||
+           s.find('[') != std::string::npos;
+}
+
+// Convert a basic glob (just *, ?, and literal chars) into a regex.
+std::regex GlobToRegex(const std::string& pattern) {
+    std::string out;
+    out.reserve(pattern.size() * 2);
+    for (char c : pattern) {
+        switch (c) {
+            case '*':
+                out += "[^/]*";
+                break;
+            case '?':
+                out += "[^/]";
+                break;
+            case '.': case '+': case '^': case '$':
+            case '(': case ')': case '[': case ']':
+            case '{': case '}': case '|': case '\\':
+                out += '\\';
+                out += c;
+                break;
+            default:
+                out += c;
+                break;
+        }
+    }
+    return std::regex(out);
+}
+
+}  // namespace
+
+EmbeddedFileSystem::EmbeddedFileSystem(std::shared_ptr<const ArchiveEntries> entries)
+    : _entries(std::move(entries)) {
+    if (_entries == nullptr) {
+        throw std::invalid_argument(
+            "EmbeddedFileSystem requires non-null ArchiveEntries");
+    }
+}
+
+bool EmbeddedFileSystem::CanHandleFile(const std::string& fpath) {
+    return HasEmbedScheme(fpath);
+}
+
+::duckdb::unique_ptr<::duckdb::FileHandle> EmbeddedFileSystem::OpenFile(
+        const std::string& path,
+        ::duckdb::FileOpenFlags flags,
+        ::duckdb::optional_ptr<::duckdb::FileOpener> /*opener*/) {
+    const std::string key = StripEmbedScheme(path);
+    auto it = _entries->find(key);
+    if (it == _entries->end()) {
+        throw ::duckdb::IOException("embed://: no such entry: " + path);
+    }
+    return ::duckdb::make_uniq<EmbeddedFileHandle>(*this, path, flags, &it->second);
+}
+
+int64_t EmbeddedFileSystem::Read(::duckdb::FileHandle& handle, void* buffer, int64_t nr_bytes) {
+    auto& h = AsEmbedded(handle);
+    if (h.data() == nullptr) {
+        return 0;
+    }
+    const auto& bytes = *h.data();
+    const ::duckdb::idx_t pos = h.position();
+    if (pos >= bytes.size()) {
+        return 0;
+    }
+    const ::duckdb::idx_t remaining = bytes.size() - pos;
+    const int64_t to_copy =
+        std::min<int64_t>(nr_bytes, static_cast<int64_t>(remaining));
+    std::memcpy(buffer, bytes.data() + pos, static_cast<std::size_t>(to_copy));
+    h.set_position(pos + static_cast<::duckdb::idx_t>(to_copy));
+    return to_copy;
+}
+
+void EmbeddedFileSystem::Read(::duckdb::FileHandle& handle, void* buffer,
+                              int64_t nr_bytes, ::duckdb::idx_t location) {
+    auto& h = AsEmbedded(handle);
+    if (h.data() == nullptr) {
+        throw ::duckdb::IOException("embed://: handle has no data");
+    }
+    const auto& bytes = *h.data();
+    if (location > bytes.size() ||
+        nr_bytes < 0 ||
+        location + static_cast<::duckdb::idx_t>(nr_bytes) > bytes.size()) {
+        throw ::duckdb::IOException(
+            "embed://: positional read out of bounds for " + h.GetPath());
+    }
+    std::memcpy(buffer, bytes.data() + location, static_cast<std::size_t>(nr_bytes));
+    // Positional Read intentionally does not move the cursor (mirrors
+    // the documented FileSystem::Read(handle, buf, n, location) contract).
+}
+
+int64_t EmbeddedFileSystem::GetFileSize(::duckdb::FileHandle& handle) {
+    auto& h = AsEmbedded(handle);
+    if (h.data() == nullptr) {
+        return -1;
+    }
+    return static_cast<int64_t>(h.data()->size());
+}
+
+void EmbeddedFileSystem::Seek(::duckdb::FileHandle& handle, ::duckdb::idx_t location) {
+    auto& h = AsEmbedded(handle);
+    if (h.data() == nullptr) {
+        throw ::duckdb::IOException("embed://: handle has no data");
+    }
+    if (location > h.data()->size()) {
+        throw ::duckdb::IOException(
+            "embed://: seek beyond EOF for " + h.GetPath());
+    }
+    h.set_position(location);
+}
+
+::duckdb::idx_t EmbeddedFileSystem::SeekPosition(::duckdb::FileHandle& handle) {
+    return AsEmbedded(handle).position();
+}
+
+bool EmbeddedFileSystem::OnDiskFile(::duckdb::FileHandle& /*handle*/) {
+    return false;
+}
+
+bool EmbeddedFileSystem::FileExists(const std::string& filename,
+                                    ::duckdb::optional_ptr<::duckdb::FileOpener> /*opener*/) {
+    const std::string key = StripEmbedScheme(filename);
+    return _entries->find(key) != _entries->end();
+}
+
+::duckdb::vector<::duckdb::OpenFileInfo> EmbeddedFileSystem::Glob(
+        const std::string& path,
+        ::duckdb::FileOpener* /*opener*/) {
+    ::duckdb::vector<::duckdb::OpenFileInfo> result;
+
+    // Non-glob path: just check existence.
+    if (!ContainsGlobMeta(path)) {
+        const std::string key = StripEmbedScheme(path);
+        if (_entries->find(key) != _entries->end()) {
+            result.emplace_back(path);
+        }
+        return result;
+    }
+
+    // We only support glob inside the embed:// scheme. Mixing schemes
+    // here would be a bug in the caller.
+    if (!HasEmbedScheme(path)) {
+        return result;
+    }
+
+    const std::string key_pattern = StripEmbedScheme(path);
+    const std::regex re = GlobToRegex(key_pattern);
+
+    for (const auto& [name, _data] : *_entries) {
+        if (std::regex_match(name, re)) {
+            result.emplace_back(std::string(kEmbedScheme) + name);
+        }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+bool RegisterEmbeddedFileSystem() {
+    auto entries = FileProviderFactory::GetBundleContents();
+    if (entries == nullptr) {
+        return false;
+    }
+
+    auto dbm = DatabaseManager::getInstance();
+    if (!dbm || !dbm->isInitialized()) {
+        return false;
+    }
+
+    auto conn = dbm->getConnection();
+    if (conn == nullptr) {
+        return false;
+    }
+
+    auto* conn_wrapper = reinterpret_cast<::duckdb::Connection*>(conn);
+    if (conn_wrapper == nullptr || conn_wrapper->context == nullptr) {
+        duckdb_disconnect(&conn);
+        return false;
+    }
+
+    auto& fs = ::duckdb::FileSystem::GetFileSystem(*conn_wrapper->context);
+    fs.RegisterSubSystem(::duckdb::make_uniq<EmbeddedFileSystem>(entries));
+
+    duckdb_disconnect(&conn);
+    return true;
+}
+
+}  // namespace flapi

--- a/src/include/duckdb_embed_fs.hpp
+++ b/src/include/duckdb_embed_fs.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "archive_io.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_open_flags.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace flapi {
+
+constexpr const char* kEmbedScheme = "embed://";
+
+// DuckDB FileSystem implementation that serves entries from an
+// in-memory ZIP via the `embed://` scheme. Sibling to
+// `EmbeddedArchiveFileProvider` (#43) -- the two share one
+// `std::shared_ptr<const ArchiveEntries>` so there is exactly one
+// decompressed copy in memory.
+//
+// The spike's hard-won lesson is encoded in this override set:
+// `OpenFile` / `Read` / `Seek` / `GetFileSize` alone are not enough
+// for `read_csv()`. We also override `Glob` (path expansion happens
+// before opening) and `SeekPosition` (the base class throws
+// "not implemented" rather than no-oping for either).
+class EmbeddedFileSystem : public ::duckdb::FileSystem {
+public:
+    explicit EmbeddedFileSystem(std::shared_ptr<const ArchiveEntries> entries);
+    ~EmbeddedFileSystem() override = default;
+
+    ::duckdb::unique_ptr<::duckdb::FileHandle> OpenFile(
+        const std::string& path,
+        ::duckdb::FileOpenFlags flags,
+        ::duckdb::optional_ptr<::duckdb::FileOpener> opener = nullptr) override;
+
+    int64_t Read(::duckdb::FileHandle& handle, void* buffer, int64_t nr_bytes) override;
+    void Read(::duckdb::FileHandle& handle, void* buffer, int64_t nr_bytes,
+              ::duckdb::idx_t location) override;
+
+    int64_t GetFileSize(::duckdb::FileHandle& handle) override;
+
+    void Seek(::duckdb::FileHandle& handle, ::duckdb::idx_t location) override;
+    ::duckdb::idx_t SeekPosition(::duckdb::FileHandle& handle) override;
+
+    ::duckdb::vector<::duckdb::OpenFileInfo> Glob(
+        const std::string& path,
+        ::duckdb::FileOpener* opener = nullptr) override;
+
+    bool CanHandleFile(const std::string& fpath) override;
+    bool FileExists(const std::string& filename,
+                    ::duckdb::optional_ptr<::duckdb::FileOpener> opener = nullptr) override;
+    bool OnDiskFile(::duckdb::FileHandle& handle) override;
+    bool CanSeek() override { return true; }
+
+    std::string GetName() const override { return "embed"; }
+
+private:
+    std::shared_ptr<const ArchiveEntries> _entries;
+};
+
+// Registers an EmbeddedFileSystem on the global DuckDB instance.
+// No-op when no bundle has been set via FileProviderFactory or when
+// DatabaseManager isn't initialised yet. Returns true if a filesystem
+// was registered.
+bool RegisterEmbeddedFileSystem();
+
+}  // namespace flapi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "bundle_locator.hpp"
 #include "config_manager.hpp"
 #include "database_manager.hpp"
+#include "duckdb_embed_fs.hpp"
 #include "flapi_telemetry.hpp"
 #include "rate_limit_middleware.hpp"
 #include "config_token_utils.hpp"
@@ -411,6 +412,13 @@ int main(int argc, char* argv[])
     }
 
     initializeDatabase(config_manager);
+
+    // If a bundle was detected at startup, register the embed:// FS
+    // on the DuckDB instance so `read_csv('embed://...')` and similar
+    // calls inside SQL templates can resolve to the in-memory archive.
+    if (RegisterEmbeddedFileSystem()) {
+        CROW_LOG_INFO << "Registered embed:// DuckDB filesystem";
+    }
 
     // Configure cloud credentials in DuckDB after database is initialized
     configureCloudCredentialsInDuckDB();

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(flapi_tests
     config_service_test.cpp
     config_service_filesystem_test.cpp
     cors_policy_test.cpp
+    duckdb_embed_fs_test.cpp
     config_service_parameters_test.cpp
     config_service_slug_test.cpp
     config_service_template_lookup_test.cpp

--- a/test/cpp/duckdb_embed_fs_test.cpp
+++ b/test/cpp/duckdb_embed_fs_test.cpp
@@ -1,0 +1,178 @@
+#include <catch2/catch_test_macros.hpp>
+#include "archive_io.hpp"
+#include "duckdb_embed_fs.hpp"
+
+#include "duckdb.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace flapi;
+
+namespace {
+
+std::vector<std::uint8_t> AsBytes(const std::string& s) {
+    return std::vector<std::uint8_t>(s.begin(), s.end());
+}
+
+std::shared_ptr<const ArchiveEntries> SampleEntries() {
+    auto entries = std::make_shared<ArchiveEntries>();
+    (*entries)["data/people.csv"] =
+        AsBytes("name,age\nAlice,30\nBob,25\nCarol,40\n");
+    (*entries)["data/cities.csv"] =
+        AsBytes("city\nBerlin\nMunich\nStuttgart\n");
+    (*entries)["other/notes.txt"] = AsBytes("hi");
+    return entries;
+}
+
+}  // namespace
+
+TEST_CASE("EmbeddedFileSystem::CanHandleFile recognises embed:// paths",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    REQUIRE(fs.CanHandleFile("embed://data/people.csv"));
+    REQUIRE_FALSE(fs.CanHandleFile("/data/people.csv"));
+    REQUIRE_FALSE(fs.CanHandleFile("s3://bucket/key"));
+    REQUIRE_FALSE(fs.CanHandleFile("data/people.csv"));
+}
+
+TEST_CASE("EmbeddedFileSystem::OpenFile returns a handle for known entries",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+
+    auto handle = fs.OpenFile("embed://data/cities.csv",
+                              ::duckdb::FileOpenFlags::FILE_FLAGS_READ);
+    REQUIRE(handle != nullptr);
+    REQUIRE(fs.GetFileSize(*handle) ==
+            static_cast<int64_t>(SampleEntries()->at("data/cities.csv").size()));
+}
+
+TEST_CASE("EmbeddedFileSystem::OpenFile throws for missing entries",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    REQUIRE_THROWS(fs.OpenFile("embed://data/missing.csv",
+                                ::duckdb::FileOpenFlags::FILE_FLAGS_READ));
+}
+
+TEST_CASE("EmbeddedFileSystem::Read returns the entry bytes and advances pos",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    auto handle = fs.OpenFile("embed://data/cities.csv",
+                              ::duckdb::FileOpenFlags::FILE_FLAGS_READ);
+    REQUIRE(handle != nullptr);
+
+    std::vector<char> buf(1024, 0);
+    int64_t n = fs.Read(*handle, buf.data(), static_cast<int64_t>(buf.size()));
+    REQUIRE(n > 0);
+
+    const std::string content(buf.data(), static_cast<std::size_t>(n));
+    REQUIRE(content.find("Berlin") != std::string::npos);
+    REQUIRE(content.find("Munich") != std::string::npos);
+
+    // After consuming the entire entry, further reads return zero.
+    int64_t n2 = fs.Read(*handle, buf.data(), static_cast<int64_t>(buf.size()));
+    REQUIRE(n2 == 0);
+}
+
+TEST_CASE("EmbeddedFileSystem positional Read does not move the cursor",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    auto handle = fs.OpenFile("embed://data/cities.csv",
+                              ::duckdb::FileOpenFlags::FILE_FLAGS_READ);
+    REQUIRE(handle != nullptr);
+
+    std::vector<char> buf(5, 0);
+    fs.Read(*handle, buf.data(), 5, 5);  // skip "city\n"
+    REQUIRE(std::string(buf.data(), 5) == "Berli");
+
+    // Stream position should still be 0 (positional read doesn't move it).
+    REQUIRE(fs.SeekPosition(*handle) == 0);
+
+    // Streaming read starts at position 0.
+    std::vector<char> buf2(4, 0);
+    int64_t n = fs.Read(*handle, buf2.data(), 4);
+    REQUIRE(n == 4);
+    REQUIRE(std::string(buf2.data(), 4) == "city");
+}
+
+TEST_CASE("EmbeddedFileSystem::Seek and SeekPosition agree", "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    auto handle = fs.OpenFile("embed://data/people.csv",
+                              ::duckdb::FileOpenFlags::FILE_FLAGS_READ);
+    REQUIRE(handle != nullptr);
+
+    fs.Seek(*handle, 9);
+    REQUIRE(fs.SeekPosition(*handle) == 9);
+}
+
+TEST_CASE("EmbeddedFileSystem::Glob expands wildcards inside embed scheme",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    auto matches = fs.Glob("embed://data/*.csv");
+    REQUIRE(matches.size() == 2);
+
+    std::vector<std::string> paths;
+    paths.reserve(matches.size());
+    for (auto& m : matches) {
+        paths.push_back(m.path);
+    }
+    std::sort(paths.begin(), paths.end());
+
+    REQUIRE(paths[0] == "embed://data/cities.csv");
+    REQUIRE(paths[1] == "embed://data/people.csv");
+}
+
+TEST_CASE("EmbeddedFileSystem::Glob returns exact match for non-wildcard paths",
+          "[embed_fs]") {
+    EmbeddedFileSystem fs(SampleEntries());
+    auto matches = fs.Glob("embed://data/cities.csv");
+    REQUIRE(matches.size() == 1);
+    REQUIRE(matches[0].path == "embed://data/cities.csv");
+
+    auto none = fs.Glob("embed://data/missing.csv");
+    REQUIRE(none.empty());
+}
+
+TEST_CASE("EmbeddedFileSystem proof-of-life: read_csv('embed://...') returns rows",
+          "[embed_fs][duckdb_e2e]") {
+    ::duckdb::DuckDB db(nullptr);  // in-memory
+
+    auto& dbi = *db.instance;
+    auto& vfs = ::duckdb::FileSystem::GetFileSystem(dbi);
+    vfs.RegisterSubSystem(::duckdb::make_uniq<EmbeddedFileSystem>(SampleEntries()));
+
+    ::duckdb::Connection conn(db);
+    auto result = conn.Query(
+        "SELECT name FROM read_csv('embed://data/people.csv') ORDER BY name");
+    if (result->HasError()) {
+        FAIL("read_csv failed: " << result->GetError());
+    }
+
+    REQUIRE(result->RowCount() == 3);
+    REQUIRE(result->GetValue(0, 0).ToString() == "Alice");
+    REQUIRE(result->GetValue(0, 1).ToString() == "Bob");
+    REQUIRE(result->GetValue(0, 2).ToString() == "Carol");
+}
+
+TEST_CASE("EmbeddedFileSystem proof-of-life: read_csv with embed:// glob",
+          "[embed_fs][duckdb_e2e]") {
+    ::duckdb::DuckDB db(nullptr);
+
+    auto& dbi = *db.instance;
+    auto& vfs = ::duckdb::FileSystem::GetFileSystem(dbi);
+    vfs.RegisterSubSystem(::duckdb::make_uniq<EmbeddedFileSystem>(SampleEntries()));
+
+    ::duckdb::Connection conn(db);
+    // Glob over both CSVs - schemas differ, so use union_by_name=true.
+    auto result = conn.Query(
+        "SELECT COUNT(*) FROM read_csv('embed://data/*.csv', union_by_name=true)");
+    if (result->HasError()) {
+        FAIL("read_csv glob failed: " << result->GetError());
+    }
+    REQUIRE(result->RowCount() == 1);
+    // 3 rows in people.csv + 3 rows in cities.csv = 6.
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 6);
+}


### PR DESCRIPTION
Part of epic #40. **Stacked on #53** which is stacked on #52 which is stacked on #51.

## Summary

Adds the **DuckDB-side reader** for the embed scheme. After this PR
lands, the bundle is fully observable from both halves of flapi:
config loading via `IFileProvider` (#43) AND SQL-side `read_csv()` /
`read_parquet()` / `read_json()` / etc. via DuckDB's
`VirtualFileSystem`.

- `src/include/duckdb_embed_fs.hpp` + `src/duckdb_embed_fs.cpp` --
  `EmbeddedFileSystem` subclassing `duckdb::FileSystem`, plus the
  `RegisterEmbeddedFileSystem()` helper that wires it onto the
  running DuckDB instance.
- `src/main.cpp` -- one new call after `initializeDatabase`, logged
  at INFO when it actually registers, silent when there's no bundle.

## Why two file-system layers (and not one)

`IFileProvider` covers config loading and SQL-template reading from
flapi C++ code. But SQL templates themselves contain DuckDB calls
like `read_csv('data/foo.csv')`, and those bypass `IFileProvider`
entirely -- they go to DuckDB's `VirtualFileSystem`. Hence two
adapters over one shared `std::shared_ptr<const ArchiveEntries>`:
one decompressed map, two readers.

## The override set

The spike's hard-won lesson:

> Implementing only `OpenFile` / `Read` / `Seek` / `GetFileSize` is
> not enough to satisfy `read_csv()`. The integration also requires
> `Glob()` (read_csv expands paths before opening) and
> `SeekPosition()`. The base class throws ``not implemented'' rather
> than no-oping.

So we override:

| Method | Why |
|--------|-----|
| `OpenFile` | returns an `EmbeddedFileHandle` over the entry's bytes |
| `Read(handle, buf, n)` | streaming read, advances position |
| `Read(handle, buf, n, location)` | positional read, **does not** move the cursor |
| `GetFileSize` | entry's byte count |
| `Seek` / `SeekPosition` | streaming-position management |
| `Glob` | expands `embed://data/*.csv` to the matching entries (sorted) |
| `CanHandleFile` | claims `embed://` paths so `VirtualFileSystem` routes them here |
| `FileExists` | sanity helper |
| `OnDiskFile` | `false` (relevant for DuckDB's random-read optimisations) |
| `CanSeek` | `true` |
| `GetName` | `embed` |

## Registration in main.cpp

Once after `initializeDatabase()`:

```cpp
if (RegisterEmbeddedFileSystem()) {
    CROW_LOG_INFO << \"Registered embed:// DuckDB filesystem\";
}
```

The helper is a no-op when:
- no bundle has been set by `detectAndRegisterEmbeddedBundle()` (#43)
- `DatabaseManager` is not initialised
- the DuckDB connection / context is unreachable

Each failure mode silently returns false; the binary keeps running.

## Tests (10 cases / proof-of-life included)

| # | Test | What it asserts |
|---|------|-----------------|
| 1 | `CanHandleFile` | recognises `embed://`, rejects `/`, `s3://`, bare paths |
| 2 | `OpenFile` for known entry | non-null handle, correct size |
| 3 | `OpenFile` for missing entry | throws `IOException` |
| 4 | streaming `Read` | bytes returned, position advances, EOF returns 0 |
| 5 | positional `Read` | bytes returned, position **unchanged** |
| 6 | `Seek` + `SeekPosition` | round-trip |
| 7 | `Glob('embed://data/*.csv')` | both CSVs, sorted |
| 8 | `Glob` exact-match / missing | single result / empty |
| 9 | **proof-of-life: `read_csv`** | in-memory DuckDB + register + `SELECT name FROM read_csv('embed://data/people.csv') ORDER BY name` returns Alice/Bob/Carol |
| 10 | **proof-of-life: glob `read_csv`** | `read_csv('embed://data/*.csv', union_by_name=true)` returns 6 rows |

```
10/10 Test #77: EmbeddedFileSystem proof-of-life: read_csv with embed:// glob_test  Passed
100% tests passed, 0 tests failed out of 10
```

The two ``proof-of-life'' tests are spike behaviour #9 -- the
hardest-won evidence that the design actually works. They now run
against the flapi build of DuckDB, not the spike's standalone
amalgamation, so this is real validation that the integration
transplants cleanly.

## Test plan

- [x] 10 new tests green.
- [x] Existing 588 Catch2 tests still pass; same 2 pre-existing
      DuckDB AddressSanitizer leaks on main remain unchanged.
- [x] Smoke: `flapi --validate-config -c examples/flapi.yaml` runs
      with no \"Registered embed://\" log line (no bundle in this
      binary -- filesystem mode untouched).
- [ ] CI cross-platform once the stack lands.

Closes #44. Part of #40. Stacked on #53 -> #52 -> #51.