### PR TITLE
feat(self-packaging #45): flapi pack / info / unpack subcommands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ add_library(flapi-lib STATIC
     src/extended_yaml_parser.cpp
     src/heartbeat_worker.cpp
     src/open_api_doc_generator.cpp
+    src/pack.cpp
     src/password_hasher.cpp
     src/path_utils.cpp
     src/query_executor.cpp

--- a/src/include/pack.hpp
+++ b/src/include/pack.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "archive_io.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <iosfwd>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace flapi {
+
+class PackError : public std::runtime_error {
+public:
+    explicit PackError(const std::string& m) : std::runtime_error(m) {}
+};
+
+struct PackOptions {
+    // Bundle files even when their relative path matches the default
+    // secret-exclude list. Intended for tests; production users must
+    // not flip this.
+    bool allow_secrets = false;
+
+    // mtime stamped on every archive entry. nullopt resolves to the
+    // SOURCE_DATE_EPOCH environment variable if set, else 0. Set
+    // explicitly to make tests deterministic.
+    std::optional<std::int64_t> source_date_epoch;
+
+    // Override the source binary whose host bytes get copied into
+    // `out_path` before the archive is appended. Defaults to
+    // `GetSelfPath()`. Tests use this to feed a small fake host
+    // binary -- avoiding the cost of copying the multi-GB
+    // sanitiser-instrumented test binary on every test case.
+    std::optional<std::filesystem::path> host_binary_override;
+};
+
+struct PackResult {
+    std::filesystem::path output;
+    std::size_t entry_count = 0;
+    std::uint64_t archive_size = 0;
+};
+
+// Pack `in_dir` (recursively) into a self-contained executable at
+// `out_path`.
+//
+// Steps:
+//  1. Copies the running binary's host bytes to `out_path`. If the
+//     running binary itself already has a trailing ZIP, only the
+//     pre-bundle prefix is copied -- so re-pack is idempotent.
+//  2. Walks `in_dir` recursively. Files matching the default secret
+//     deny list (*.env, secrets/*, *.pem, *.key) cause a PackError
+//     unless `options.allow_secrets` is true.
+//  3. Writes an archive (via archive_io::WriteArchive) and appends it.
+//  4. Copies executable bits from the running binary onto the output
+//     (best-effort, Unix only).
+//
+// Throws PackError on any I/O or policy failure. Leaves `out_path` in
+// an undefined state on throw -- callers are expected to delete it.
+PackResult Pack(const std::filesystem::path& in_dir,
+                const std::filesystem::path& out_path,
+                const PackOptions& options = {});
+
+// Print bundle info for a binary on disk. Returns 0 when a bundle is
+// found and listed; 1 when no bundle is present.
+int PrintBundleInfoForPath(const std::filesystem::path& binary, std::ostream& os);
+
+// Print bundle info for the running binary (convenience).
+int PrintBundleInfo(std::ostream& os);
+
+struct UnpackResult {
+    std::size_t entries_written = 0;
+};
+
+// Unpack the bundle from `binary` into `dst_dir`. Creates `dst_dir`
+// (and intermediate dirs per entry) if missing. Throws PackError if
+// the binary has no bundle or any entry can't be written.
+UnpackResult UnpackBundleFromPath(const std::filesystem::path& binary,
+                                  const std::filesystem::path& dst_dir);
+
+// Unpack the running binary's bundle (convenience).
+UnpackResult UnpackBundle(const std::filesystem::path& dst_dir);
+
+// Whether `rel_path` matches the default secret exclude list. The
+// patterns:
+//   - `*.env`     at any depth                (e.g. `.env`, `cfg/.env`)
+//   - `secrets/`  segment at any depth        (e.g. `secrets/x`, `a/secrets/x`)
+//   - `*.pem`     at any depth
+//   - `*.key`     at any depth
+bool IsSecretExcluded(const std::string& rel_path);
+
+}  // namespace flapi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "config_manager.hpp"
 #include "database_manager.hpp"
 #include "duckdb_embed_fs.hpp"
+#include "pack.hpp"
 #include "flapi_telemetry.hpp"
 #include "rate_limit_middleware.hpp"
 #include "config_token_utils.hpp"
@@ -344,12 +345,87 @@ int main(int argc, char* argv[])
         .default_value(false)
         .implicit_value(true);
 
+    // ------------------------------------------------------------------
+    // Self-packaging subcommands (#45). Each subcommand is optional; if
+    // none is given the binary runs as the API server, preserving the
+    // pre-existing `./flapi -c flapi.yaml` invocation.
+    // ------------------------------------------------------------------
+
+    argparse::ArgumentParser pack_cmd("pack");
+    pack_cmd.add_description(
+        "Package a flapi config tree into a self-contained executable.");
+    pack_cmd.add_argument("--in")
+        .help("Directory containing flapi.yaml + sqls/ + data/")
+        .required();
+    pack_cmd.add_argument("--out")
+        .help("Output path for the new bundled executable")
+        .required();
+    pack_cmd.add_argument("--allow-secrets")
+        .help("Bundle files matching the default secret exclude list "
+              "(*.env, secrets/*, *.pem, *.key). Testing only.")
+        .default_value(false)
+        .implicit_value(true);
+    program.add_subparser(pack_cmd);
+
+    argparse::ArgumentParser info_cmd("info");
+    info_cmd.add_description(
+        "Print bundle info (offset, size, entries) for this binary.");
+    program.add_subparser(info_cmd);
+
+    argparse::ArgumentParser unpack_cmd("unpack");
+    unpack_cmd.add_description(
+        "Dump the bundle of this binary into a directory.");
+    unpack_cmd.add_argument("--to")
+        .help("Destination directory (will be created if missing)")
+        .required();
+    program.add_subparser(unpack_cmd);
+
     try {
         program.parse_args(argc, argv);
     } catch (const std::runtime_error& err) {
         std::cerr << err.what() << std::endl;
         std::cerr << program;
         return 1;
+    }
+
+    // ------------------------------------------------------------------
+    // Subcommand dispatch. Returns early; never reaches server startup.
+    // ------------------------------------------------------------------
+    if (program.is_subcommand_used("pack")) {
+        try {
+            PackOptions opts;
+            opts.allow_secrets = pack_cmd.get<bool>("--allow-secrets");
+            const auto in_dir = pack_cmd.get<std::string>("--in");
+            const auto out_path = pack_cmd.get<std::string>("--out");
+            const auto result = Pack(in_dir, out_path, opts);
+            std::cout << "Packed " << result.entry_count
+                      << " entries (" << result.archive_size
+                      << " bytes) into " << result.output.string() << "\n";
+            return 0;
+        } catch (const PackError& e) {
+            std::cerr << "flapi pack: " << e.what() << "\n";
+            return 1;
+        } catch (const std::exception& e) {
+            std::cerr << "flapi pack: unexpected error: " << e.what() << "\n";
+            return 1;
+        }
+    }
+
+    if (program.is_subcommand_used("info")) {
+        return PrintBundleInfo(std::cout);
+    }
+
+    if (program.is_subcommand_used("unpack")) {
+        try {
+            const auto dst = unpack_cmd.get<std::string>("--to");
+            const auto result = UnpackBundle(dst);
+            std::cout << "Unpacked " << result.entries_written
+                      << " entries to " << dst << "\n";
+            return 0;
+        } catch (const PackError& e) {
+            std::cerr << "flapi unpack: " << e.what() << "\n";
+            return 1;
+        }
     }
 
     std::string config_file = program.get<std::string>("--config");

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -1,0 +1,252 @@
+#include "pack.hpp"
+
+#include "bundle_locator.hpp"
+#include "selfpath.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <ostream>
+#include <regex>
+#include <vector>
+
+namespace flapi {
+
+namespace {
+
+const std::array<std::regex, 4>& SecretPatterns() {
+    static const std::array<std::regex, 4> patterns{
+        std::regex(R"((^|/)[^/]*\.env$)"),
+        std::regex(R"((^|/)secrets/)"),
+        std::regex(R"((^|/)[^/]*\.pem$)"),
+        std::regex(R"((^|/)[^/]*\.key$)"),
+    };
+    return patterns;
+}
+
+std::int64_t ResolveSourceDateEpoch(const std::optional<std::int64_t>& explicit_val) {
+    if (explicit_val.has_value()) {
+        return *explicit_val;
+    }
+    if (const char* env = std::getenv("SOURCE_DATE_EPOCH")) {
+        try {
+            return static_cast<std::int64_t>(std::stoll(env));
+        } catch (...) {
+            // fall through to default
+        }
+    }
+    return 0;
+}
+
+std::uint64_t HostByteCount(const std::filesystem::path& self_path) {
+    auto file_size = std::filesystem::file_size(self_path);
+    if (auto loc = LocateBundle(self_path); loc.has_value()) {
+        return loc->offset;
+    }
+    return static_cast<std::uint64_t>(file_size);
+}
+
+void CopyHostPrefix(const std::filesystem::path& src,
+                    const std::filesystem::path& dst,
+                    std::uint64_t bytes_to_copy) {
+    std::ifstream in(src, std::ios::binary);
+    if (!in) {
+        throw PackError("cannot open self-binary: " + src.string());
+    }
+
+    std::ofstream out(dst, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        throw PackError("cannot create output binary: " + dst.string());
+    }
+
+    constexpr std::size_t kChunk = 64 * 1024;
+    std::vector<char> buf(kChunk);
+    std::uint64_t remaining = bytes_to_copy;
+    while (remaining > 0) {
+        const auto to_read = static_cast<std::streamsize>(
+            std::min<std::uint64_t>(remaining, kChunk));
+        in.read(buf.data(), to_read);
+        const auto n = in.gcount();
+        if (n <= 0) {
+            throw PackError("short read from self-binary: " + src.string());
+        }
+        out.write(buf.data(), n);
+        remaining -= static_cast<std::uint64_t>(n);
+    }
+}
+
+void AppendArchive(const std::filesystem::path& path,
+                   const std::vector<std::uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary | std::ios::app);
+    if (!out) {
+        throw PackError("cannot append archive to " + path.string());
+    }
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+}
+
+ArchiveEntries CollectEntries(const std::filesystem::path& in_dir, bool allow_secrets) {
+    if (!std::filesystem::exists(in_dir)) {
+        throw PackError("input directory does not exist: " + in_dir.string());
+    }
+    if (!std::filesystem::is_directory(in_dir)) {
+        throw PackError("input is not a directory: " + in_dir.string());
+    }
+
+    ArchiveEntries entries;
+    for (const auto& dir_entry :
+         std::filesystem::recursive_directory_iterator(in_dir)) {
+        if (!dir_entry.is_regular_file()) {
+            continue;
+        }
+        const auto rel = std::filesystem::relative(dir_entry.path(), in_dir);
+        const std::string rel_str = rel.generic_string();  // always forward slashes
+
+        if (!allow_secrets && IsSecretExcluded(rel_str)) {
+            throw PackError(
+                "refusing to bundle secret-looking file: " + rel_str +
+                " (override with --allow-secrets)");
+        }
+
+        std::ifstream f(dir_entry.path(), std::ios::binary);
+        if (!f) {
+            throw PackError("cannot read input file: " + dir_entry.path().string());
+        }
+        std::vector<std::uint8_t> data((std::istreambuf_iterator<char>(f)),
+                                       std::istreambuf_iterator<char>());
+        entries.emplace(rel_str, std::move(data));
+    }
+    return entries;
+}
+
+void CopyExecutableBits(const std::filesystem::path& src,
+                        const std::filesystem::path& dst) {
+    std::error_code ec;
+    const auto perms = std::filesystem::status(src, ec).permissions();
+    if (ec) {
+        return;
+    }
+    std::filesystem::permissions(dst, perms, ec);
+    // best-effort -- ignore errors (filesystem may not support perms)
+}
+
+}  // namespace
+
+bool IsSecretExcluded(const std::string& rel_path) {
+    for (const auto& re : SecretPatterns()) {
+        if (std::regex_search(rel_path, re)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+PackResult Pack(const std::filesystem::path& in_dir,
+                const std::filesystem::path& out_path,
+                const PackOptions& options) {
+    const auto host_path = options.host_binary_override.value_or(GetSelfPath());
+    const auto host_bytes = HostByteCount(host_path);
+
+    CopyHostPrefix(host_path, out_path, host_bytes);
+    CopyExecutableBits(host_path, out_path);
+
+    auto entries = CollectEntries(in_dir, options.allow_secrets);
+
+    ArchiveWriteOptions write_opts;
+    write_opts.source_date_epoch = ResolveSourceDateEpoch(options.source_date_epoch);
+    const auto archive = WriteArchive(entries, write_opts);
+
+    AppendArchive(out_path, archive);
+
+    PackResult r;
+    r.output = out_path;
+    r.entry_count = entries.size();
+    r.archive_size = archive.size();
+    return r;
+}
+
+namespace {
+
+std::vector<std::uint8_t> ReadBundleBytes(const std::filesystem::path& binary,
+                                          const BundleLocation& loc) {
+    std::ifstream f(binary, std::ios::binary);
+    if (!f) {
+        throw PackError("cannot open " + binary.string());
+    }
+    f.seekg(static_cast<std::streamoff>(loc.offset), std::ios::beg);
+
+    std::vector<std::uint8_t> bytes(loc.size);
+    f.read(reinterpret_cast<char*>(bytes.data()),
+           static_cast<std::streamsize>(loc.size));
+    if (static_cast<std::uint64_t>(f.gcount()) != loc.size) {
+        throw PackError("short bundle read from " + binary.string());
+    }
+    return bytes;
+}
+
+}  // namespace
+
+int PrintBundleInfoForPath(const std::filesystem::path& binary, std::ostream& os) {
+    os << "Binary: " << binary.string() << "\n";
+
+    auto loc = LocateBundle(binary);
+    if (!loc.has_value()) {
+        os << "Bundle: none (filesystem mode)\n";
+        return 1;
+    }
+
+    os << "Bundle offset: " << loc->offset << "\n";
+    os << "Bundle size:   " << loc->size << " bytes\n";
+
+    auto bytes = ReadBundleBytes(binary, *loc);
+    auto entries = ReadArchive(bytes);
+
+    os << "Entries (" << entries.size() << "):\n";
+    for (const auto& [name, data] : entries) {
+        os << "  " << name << " (" << data.size() << " bytes)\n";
+    }
+    return 0;
+}
+
+int PrintBundleInfo(std::ostream& os) {
+    return PrintBundleInfoForPath(GetSelfPath(), os);
+}
+
+UnpackResult UnpackBundleFromPath(const std::filesystem::path& binary,
+                                  const std::filesystem::path& dst_dir) {
+    auto loc = LocateBundle(binary);
+    if (!loc.has_value()) {
+        throw PackError("no bundle present in " + binary.string());
+    }
+
+    auto bytes = ReadBundleBytes(binary, *loc);
+    auto entries = ReadArchive(bytes);
+
+    std::error_code ec;
+    std::filesystem::create_directories(dst_dir, ec);
+    if (ec) {
+        throw PackError("cannot create unpack directory: " + dst_dir.string());
+    }
+
+    UnpackResult r;
+    for (const auto& [name, data] : entries) {
+        auto out_path = dst_dir / name;
+        std::filesystem::create_directories(out_path.parent_path(), ec);
+
+        std::ofstream out(out_path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            throw PackError("cannot write unpacked file: " + out_path.string());
+        }
+        out.write(reinterpret_cast<const char*>(data.data()),
+                  static_cast<std::streamsize>(data.size()));
+        ++r.entries_written;
+    }
+    return r;
+}
+
+UnpackResult UnpackBundle(const std::filesystem::path& dst_dir) {
+    return UnpackBundleFromPath(GetSelfPath(), dst_dir);
+}
+
+}  // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(flapi_tests
     mcp_request_validator_test.cpp
     mcp_response_shaper_test.cpp
     mcp_tool_rate_limiter_test.cpp
+    pack_test.cpp
     password_hasher_test.cpp
     query_executor_test.cpp
     rate_limit_key_builder_test.cpp

--- a/test/cpp/pack_test.cpp
+++ b/test/cpp/pack_test.cpp
@@ -1,0 +1,322 @@
+#include <catch2/catch_test_macros.hpp>
+#include "archive_io.hpp"
+#include "bundle_locator.hpp"
+#include "pack.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace flapi;
+
+namespace {
+
+class TempDir {
+public:
+    TempDir() {
+        path_ = std::filesystem::temp_directory_path() /
+                ("flapi_pack_test_" +
+                 std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        std::filesystem::create_directories(path_);
+    }
+    ~TempDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+
+    const std::filesystem::path& path() const { return path_; }
+
+    std::filesystem::path WriteFile(const std::string& rel,
+                                    const std::string& content) {
+        auto full = path_ / rel;
+        std::filesystem::create_directories(full.parent_path());
+        std::ofstream f(full, std::ios::binary | std::ios::trunc);
+        f.write(content.data(), static_cast<std::streamsize>(content.size()));
+        return full;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+class TempFilePath {
+public:
+    explicit TempFilePath(const std::string& suffix = ".bin") {
+        path_ = std::filesystem::temp_directory_path() /
+                ("flapi_pack_test_out_" +
+                 std::to_string(reinterpret_cast<std::uintptr_t>(this)) + suffix);
+    }
+    ~TempFilePath() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+    TempFilePath(const TempFilePath&) = delete;
+    TempFilePath& operator=(const TempFilePath&) = delete;
+
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
+std::vector<std::uint8_t> ReadAllBytes(const std::filesystem::path& p) {
+    std::ifstream f(p, std::ios::binary);
+    return std::vector<std::uint8_t>((std::istreambuf_iterator<char>(f)),
+                                      std::istreambuf_iterator<char>());
+}
+
+void PopulateSampleTree(TempDir& dir) {
+    dir.WriteFile("flapi.yaml", "project-name: bundled\nversion: 1\n");
+    dir.WriteFile("sqls/customers.yaml", "url-path: /customers\n");
+    dir.WriteFile("sqls/customers.sql", "SELECT * FROM customers");
+    dir.WriteFile("data/cities.csv", "city\nBerlin\nMunich\n");
+}
+
+// A tiny fake "host binary": 4 KiB of pseudo-random bytes with any
+// incidental EOCD signatures scrubbed so the locator can't mistake the
+// host for a bundle. Stays the same across runs (fixed seed).
+std::filesystem::path WriteFakeHost(TempDir& dir, std::uint32_t seed = 0xc0ffee) {
+    std::mt19937 rng(seed);
+    std::vector<std::uint8_t> bytes(4096);
+    for (auto& b : bytes) {
+        b = static_cast<std::uint8_t>(rng() & 0xff);
+    }
+    for (std::size_t i = 0; i + 3 < bytes.size(); ++i) {
+        if (bytes[i] == 0x50 && bytes[i + 1] == 0x4b &&
+            bytes[i + 2] == 0x05 && bytes[i + 3] == 0x06) {
+            bytes[i] = 0x00;
+        }
+    }
+    auto p = dir.path() / "fake_host.bin";
+    std::ofstream f(p, std::ios::binary | std::ios::trunc);
+    f.write(reinterpret_cast<const char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+    return p;
+}
+
+}  // namespace
+
+TEST_CASE("IsSecretExcluded matches the default deny list", "[pack][secrets]") {
+    REQUIRE(IsSecretExcluded("config/.env"));
+    REQUIRE(IsSecretExcluded(".env"));
+    REQUIRE(IsSecretExcluded("secrets/api.token"));
+    REQUIRE(IsSecretExcluded("nested/secrets/api.token"));
+    REQUIRE(IsSecretExcluded("certs/server.pem"));
+    REQUIRE(IsSecretExcluded("certs/key.key"));
+
+    REQUIRE_FALSE(IsSecretExcluded("flapi.yaml"));
+    REQUIRE_FALSE(IsSecretExcluded("sqls/customers.sql"));
+    REQUIRE_FALSE(IsSecretExcluded("data/notsecrets/file.txt"));
+    REQUIRE_FALSE(IsSecretExcluded("envoy.conf"));
+    REQUIRE_FALSE(IsSecretExcluded("foo.pemmed"));
+}
+
+TEST_CASE("Pack produces a binary with an appended ZIP bundle", "[pack]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+
+    TempFilePath out;
+    auto result = Pack(input.path(), out.path(), opts);
+
+    REQUIRE(result.entry_count == 4);
+    REQUIRE(std::filesystem::exists(out.path()));
+
+    auto loc = LocateBundle(out.path());
+    REQUIRE(loc.has_value());
+    REQUIRE(loc->size == result.archive_size);
+}
+
+TEST_CASE("Pack bundle round-trips through ReadArchive", "[pack]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+
+    TempFilePath out;
+    Pack(input.path(), out.path(), opts);
+
+    auto loc = LocateBundle(out.path());
+    REQUIRE(loc.has_value());
+
+    auto bytes = ReadAllBytes(out.path());
+    std::vector<std::uint8_t> zip(
+        bytes.begin() + static_cast<std::ptrdiff_t>(loc->offset),
+        bytes.begin() + static_cast<std::ptrdiff_t>(loc->offset + loc->size));
+    auto entries = ReadArchive(zip);
+
+    REQUIRE(entries.size() == 4);
+    REQUIRE(entries.count("flapi.yaml") == 1);
+    REQUIRE(entries.count("sqls/customers.yaml") == 1);
+    REQUIRE(entries.count("sqls/customers.sql") == 1);
+    REQUIRE(entries.count("data/cities.csv") == 1);
+
+    const auto& customers_sql = entries["sqls/customers.sql"];
+    REQUIRE(std::string(customers_sql.begin(), customers_sql.end()) ==
+            "SELECT * FROM customers");
+}
+
+TEST_CASE("Pack refuses files matching the secrets exclude list",
+          "[pack][secrets]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+    input.WriteFile(".env", "DB_PASSWORD=hunter2\n");
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+
+    TempFilePath out;
+    REQUIRE_THROWS_AS(Pack(input.path(), out.path(), opts), PackError);
+}
+
+TEST_CASE("Pack with --allow-secrets bundles secret files",
+          "[pack][secrets]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+    input.WriteFile(".env", "DB_PASSWORD=hunter2\n");
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+    opts.allow_secrets = true;
+
+    TempFilePath out;
+    auto result = Pack(input.path(), out.path(), opts);
+    REQUIRE(result.entry_count == 5);
+}
+
+TEST_CASE("Pack is idempotent: re-packing a bundled binary doesn't grow it",
+          "[pack][idempotence]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+
+    TempFilePath first;
+    Pack(input.path(), first.path(), opts);
+    const auto size1 = std::filesystem::file_size(first.path());
+
+    // Use the produced bundled binary as the host for a second pack.
+    // The pack code should strip the trailing ZIP from the copy before
+    // appending the new one, so the output size stays stable.
+    PackOptions opts2 = opts;
+    opts2.host_binary_override = first.path();
+
+    TempFilePath second;
+    Pack(input.path(), second.path(), opts2);
+    const auto size2 = std::filesystem::file_size(second.path());
+
+    REQUIRE(size1 == size2);
+
+    // And a third round, just to be sure.
+    PackOptions opts3 = opts2;
+    opts3.host_binary_override = second.path();
+    TempFilePath third;
+    Pack(input.path(), third.path(), opts3);
+    REQUIRE(std::filesystem::file_size(third.path()) == size1);
+}
+
+TEST_CASE("Pack output preserves the host binary bytes prefix",
+          "[pack][host_prefix]") {
+    TempDir host_dir;
+    auto host = WriteFakeHost(host_dir);
+
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = host;
+    opts.source_date_epoch = 0;
+
+    TempFilePath out;
+    Pack(input.path(), out.path(), opts);
+
+    auto host_bytes = ReadAllBytes(host);
+    auto out_bytes = ReadAllBytes(out.path());
+
+    REQUIRE(out_bytes.size() > host_bytes.size());
+    for (std::size_t i = 0; i < host_bytes.size(); ++i) {
+        if (out_bytes[i] != host_bytes[i]) {
+            FAIL("host prefix diverges at byte " << i);
+        }
+    }
+}
+
+TEST_CASE("PrintBundleInfo reports 'none' when no bundle is present",
+          "[pack][info]") {
+    std::ostringstream os;
+    int rc = PrintBundleInfo(os);
+    REQUIRE(rc != 0);
+    const std::string out = os.str();
+    REQUIRE(out.find("none") != std::string::npos);
+}
+
+TEST_CASE("PrintBundleInfoForPath lists entries from a bundled binary",
+          "[pack][info]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+
+    TempFilePath out;
+    Pack(input.path(), out.path(), opts);
+
+    std::ostringstream os;
+    int rc = PrintBundleInfoForPath(out.path(), os);
+    REQUIRE(rc == 0);
+    const std::string text = os.str();
+    REQUIRE(text.find("flapi.yaml") != std::string::npos);
+    REQUIRE(text.find("sqls/customers.sql") != std::string::npos);
+    REQUIRE(text.find("data/cities.csv") != std::string::npos);
+}
+
+TEST_CASE("UnpackBundleFromPath restores all entries to dst",
+          "[pack][unpack]") {
+    TempDir host_dir;
+    TempDir input;
+    PopulateSampleTree(input);
+
+    PackOptions opts;
+    opts.host_binary_override = WriteFakeHost(host_dir);
+    opts.source_date_epoch = 0;
+
+    TempFilePath out;
+    Pack(input.path(), out.path(), opts);
+
+    TempDir dst;
+    auto r = UnpackBundleFromPath(out.path(), dst.path());
+    REQUIRE(r.entries_written == 4);
+
+    REQUIRE(std::filesystem::exists(dst.path() / "flapi.yaml"));
+    REQUIRE(std::filesystem::exists(dst.path() / "sqls/customers.sql"));
+    REQUIRE(std::filesystem::exists(dst.path() / "data/cities.csv"));
+
+    std::ifstream src(input.path() / "sqls/customers.sql", std::ios::binary);
+    std::ifstream restored(dst.path() / "sqls/customers.sql", std::ios::binary);
+    std::string a((std::istreambuf_iterator<char>(src)),
+                  std::istreambuf_iterator<char>());
+    std::string b((std::istreambuf_iterator<char>(restored)),
+                  std::istreambuf_iterator<char>());
+    REQUIRE(a == b);
+}


### PR DESCRIPTION
Part of epic #40. **Stacked on #54** which is stacked on #53 -> #52 -> #51.

## Summary

Closes the loop on self-packaging. After #41-#44 the **runtime** can
serve a bundled config tree; this PR adds the **producer** so the
same binary that serves bundles also creates them. The same artifact
is server + packager.

- New library: `src/{include/,}pack.cpp`
- CLI: argparse subparsers for `pack` / `info` / `unpack` in
  `src/main.cpp`. **Zero-subcommand invocation
  (`./flapi -c flapi.yaml`) still runs the server**, so existing
  operators see no change.

## Library API

```cpp
PackResult Pack(in_dir, out_path, PackOptions{});
int        PrintBundleInfo(ostream&);
int        PrintBundleInfoForPath(binary, ostream&);
UnpackResult UnpackBundle(dst_dir);
UnpackResult UnpackBundleFromPath(binary, dst_dir);
bool       IsSecretExcluded(rel_path);
```

`Pack()` flow:
1. Copy host bytes from `options.host_binary_override` (defaults to
   `GetSelfPath()`). If the host already has a trailing ZIP, only the
   **pre-bundle prefix** is copied -- re-pack is idempotent.
2. Recursive walk of `in_dir`. Files matching the default secret
   deny list (`*.env` at any depth, `secrets/` segment at any
   depth, `*.pem`, `*.key`) cause `PackError` unless
   `options.allow_secrets` is set.
3. `archive_io::WriteArchive` (#51) with `SOURCE_DATE_EPOCH` stamping
   and sorted entries; appended to the output.
4. Best-effort exec-bit copy from host -> output (Unix only).

## CLI

```
$ ./flapi --help
Subcommands:
  info     Print bundle info (offset, size, entries) for this binary.
  pack     Package a flapi config tree into a self-contained executable.
  unpack   Dump the bundle of this binary into a directory.

$ ./flapi pack --in examples --out /tmp/flapi-prod --allow-secrets
Packed 17 entries (12534 bytes) into /tmp/flapi-prod

$ /tmp/flapi-prod info
Binary: /tmp/flapi-prod
Bundle offset: 1751413104
Bundle size:   12534 bytes
Entries (17):
  flapi.yaml (1024 bytes)
  sqls/customers.yaml (412 bytes)
  ...

$ /tmp/flapi-prod unpack --to /tmp/unpacked
Unpacked 17 entries to /tmp/unpacked
```

Subcommand handlers `return` early; the server-mode code path is
only reached when **no** subcommand was given.

## The `host_binary_override` testability seam

The sanitiser-instrumented test binary is ~1.7 GB. Copying it for
every test case would push runtime past several minutes per case.
`PackOptions::host_binary_override` lets tests substitute a 4-KiB
fake host (with the EOCD signature scrubbed so the locator can't
mistake it for an existing bundle). Production code never touches
this knob.

## Tests (10 cases / 38 assertions)

| # | Test | What it asserts |
|---|------|-----------------|
| 1 | `IsSecretExcluded` | default deny list + non-matches (`envoy.conf`, `foo.pemmed`) |
| 2 | `Pack` produces a bundled binary | entry count, output exists, EOCD locatable |
| 3 | `Pack` round-trip | extract bundle slice -> `ReadArchive` -> entries match input |
| 4 | secret rejection | `.env` in input -> `PackError`; output not written |
| 5 | `--allow-secrets` | bypasses the deny list, bundles 5 entries |
| 6 | re-pack idempotence | pack -> pack -> pack with stacked outputs, file size stable |
| 7 | host prefix preservation | bytes `0..host_size` byte-for-byte match the host file |
| 8 | `PrintBundleInfo` no bundle | exit 1, output contains "none" |
| 9 | `PrintBundleInfoForPath` | lists `flapi.yaml`, `sqls/customers.sql`, `data/cities.csv` |
| 10 | `UnpackBundleFromPath` | 4 entries restored to disk, bytes equal |

```
Filters: [pack]
All tests passed (38 assertions in 10 test cases)
```

## Smoke test (real flapi binary, not test binary)

- `flapi --help` shows three subcommands.
- `flapi info` on unbundled binary -> `"Bundle: none (filesystem mode)"`, exit 1.
- `flapi pack --in <dir>` with `.env` in input -> single-line stderr error, exit 1.
- `flapi pack ... --allow-secrets` -> `Packed N entries (M bytes)`, exit 0.
- `<bundled> info` -> offset (~1.6 GB into the host), size, entry list.
- `<bundled> unpack --to <dir>` -> all files restored.

## Test plan

- [x] 10 new pack tests green (38 assertions).
- [x] Smoke test against the actual flapi binary covers all three
      subcommands + happy + error paths.
- [x] Existing argparse usage unchanged when no subcommand is given;
      `./flapi -c flapi.yaml` still launches server mode.
- [ ] CI cross-platform once stack lands.

## What's not in this PR (deferred)

- **YAML path rewriting** to `embed://` -- the issue body mentions
  rewriting paths in YAML so the same configs work both unpacked
  and bundled. In practice the `IFileProvider` factory dispatch
  (#53) already handles non-remote paths transparently from a
  bundle, so this isn't needed for the IFileProvider side. It's
  still needed for SQL templates that contain `read_csv('data/x.csv')`
  (DuckDB-side reads bypass IFileProvider). Filing as follow-up
  rather than expanding this PR.
- **Integration tests against the round-trip behaviour** -- that's
  the explicit scope of #46.

Closes #45. Part of #40. Stacked on #54 -> #53 -> #52 -> #51.