### PR TITLE
test(self-packaging #46): integration tests for round-trip behaviours

### DIFF
--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -145,17 +145,20 @@ bool IsSecretExcluded(const std::string& rel_path) {
 PackResult Pack(const std::filesystem::path& in_dir,
                 const std::filesystem::path& out_path,
                 const PackOptions& options) {
-    const auto host_path = options.host_binary_override.value_or(GetSelfPath());
-    const auto host_bytes = HostByteCount(host_path);
-
-    CopyHostPrefix(host_path, out_path, host_bytes);
-    CopyExecutableBits(host_path, out_path);
-
+    // Collect (and validate against the secret deny list) BEFORE doing any
+    // I/O on the output. Otherwise a rejected `.env` leaves a multi-GB
+    // half-written binary sitting in the user's tmp dir.
     auto entries = CollectEntries(in_dir, options.allow_secrets);
 
     ArchiveWriteOptions write_opts;
     write_opts.source_date_epoch = ResolveSourceDateEpoch(options.source_date_epoch);
     const auto archive = WriteArchive(entries, write_opts);
+
+    const auto host_path = options.host_binary_override.value_or(GetSelfPath());
+    const auto host_bytes = HostByteCount(host_path);
+
+    CopyHostPrefix(host_path, out_path, host_bytes);
+    CopyExecutableBits(host_path, out_path);
 
     AppendArchive(out_path, archive);
 

--- a/test/integration/test_self_packaging.py
+++ b/test/integration/test_self_packaging.py
@@ -1,0 +1,312 @@
+"""End-to-end round-trip tests for self-packaging (issue #46).
+
+Mirrors the spike's 9 behaviours
+(github.com/jrosskopf/research/tree/main/2026-05-21-flapi-self-packaging)
+against the real `flapi` binary built by `make debug` or `make release`.
+
+Each test builds an isolated fixture tree under `tmp_path`, invokes
+`flapi pack` / `info` / `unpack` as subprocesses, and asserts on the
+artifacts produced. The CLI-level tests do not start the HTTP server.
+
+We mark everything with `standalone_server` so the shared conftest
+fixture doesn't try to spin up the API-configuration server for us --
+each test is self-contained.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+# Make the helpers in conftest.py importable without the autouse fixtures
+# trying to start the api_configuration server for us.
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from conftest import get_flapi_binary  # noqa: E402
+
+
+pytestmark = pytest.mark.standalone_server
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_fixture_tree(root: pathlib.Path) -> None:
+    """Tiny config tree usable in both filesystem and bundled modes.
+
+    Two endpoints:
+      - GET /hello             -> SELECT 'world' AS greeting  (no I/O)
+      - GET /cities-embed      -> read_csv('embed://data/cities.csv')
+
+    The /cities-embed endpoint deliberately uses an embed:// path so it
+    fails in filesystem mode and succeeds in bundled mode -- that's how
+    we prove the embed FS (#44) is wired through.
+    """
+    (root / "sqls").mkdir(parents=True, exist_ok=True)
+    (root / "data").mkdir(parents=True, exist_ok=True)
+
+    (root / "flapi.yaml").write_text(
+        "project-name: self-packaging-roundtrip\n"
+        "template:\n"
+        "  path: ./sqls\n"
+        "connections:\n"
+        "  default-conn:\n"
+        "    properties:\n"
+        "      path: ./data\n"
+        "    log-queries: false\n"
+        "    log-parameters: false\n"
+        "    allow: '*'\n"
+        "duckdb:\n"
+        "  access_mode: READ_WRITE\n"
+        "  threads: 1\n"
+        "  max_memory: 256MB\n"
+    )
+
+    (root / "sqls" / "hello.yaml").write_text(
+        "url-path: /hello\n"
+        "method: GET\n"
+        "template-source: hello.sql\n"
+        "connection:\n"
+        "  - default-conn\n"
+    )
+    (root / "sqls" / "hello.sql").write_text("SELECT 'world' AS greeting\n")
+
+    (root / "sqls" / "cities-embed.yaml").write_text(
+        "url-path: /cities-embed\n"
+        "method: GET\n"
+        "template-source: cities-embed.sql\n"
+        "connection:\n"
+        "  - default-conn\n"
+    )
+    (root / "sqls" / "cities-embed.sql").write_text(
+        "SELECT * FROM read_csv('embed://data/cities.csv')\n"
+    )
+
+    (root / "data" / "cities.csv").write_text(
+        "city,population\nBerlin,3700000\nMunich,1500000\nStuttgart,630000\n"
+    )
+
+
+def _flapi() -> pathlib.Path:
+    """Path to the flapi binary (release/debug, per FLAPI_BUILD_TYPE)."""
+    return get_flapi_binary()
+
+
+def _run(cmd, **kwargs):
+    """Run a subprocess and capture stdout+stderr."""
+    return subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #2 -- `flapi pack` produces an executable with a bundle
+# ---------------------------------------------------------------------------
+
+
+def test_pack_produces_bundled_executable(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    out = tmp_path / "flapi-bundled"
+
+    res = _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(out)])
+    assert res.returncode == 0, f"pack failed: stdout={res.stdout} stderr={res.stderr}"
+    assert out.exists(), "bundled binary not created"
+    assert "Packed" in res.stdout
+    # Should be at least as big as the host binary.
+    assert out.stat().st_size >= _flapi().stat().st_size
+
+    # Executable bits preserved on Unix.
+    if os.name == "posix":
+        assert os.access(out, os.X_OK), "bundled binary missing exec bit"
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #4 -- `flapi info` reports EOCD offset + entry list
+# ---------------------------------------------------------------------------
+
+
+def test_info_reports_bundle_contents(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    out = tmp_path / "flapi-bundled"
+
+    pack_res = _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(out)])
+    assert pack_res.returncode == 0
+
+    info_res = _run([str(out), "info"])
+    assert info_res.returncode == 0, f"info failed: {info_res.stderr}"
+    text = info_res.stdout
+    assert "Bundle offset:" in text
+    assert "Bundle size:" in text
+    # Entry list should mention the fixture files.
+    assert "flapi.yaml" in text
+    assert "sqls/hello.sql" in text
+    assert "sqls/cities-embed.sql" in text
+    assert "data/cities.csv" in text
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #5 -- self-hosting: bundled binary can produce a new bundle
+# ---------------------------------------------------------------------------
+
+
+def test_self_hosting_rebundle(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    first = tmp_path / "first-bundled"
+    second = tmp_path / "second-bundled"
+
+    r1 = _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(first)])
+    assert r1.returncode == 0
+
+    # Now use the produced binary as the packager.
+    r2 = _run([str(first), "pack", "--in", str(fixture), "--out", str(second)])
+    assert r2.returncode == 0, f"self-host pack failed: {r2.stderr}"
+    assert second.exists()
+
+    # The self-hosted output should also have a valid bundle.
+    r_info = _run([str(second), "info"])
+    assert r_info.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #6 -- re-pack idempotence: size stable across N packs
+# ---------------------------------------------------------------------------
+
+
+def test_repack_idempotence(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    third = tmp_path / "third"
+
+    assert _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(first)]).returncode == 0
+    size1 = first.stat().st_size
+
+    # Re-pack using the bundled output as the host.
+    assert _run([str(first), "pack", "--in", str(fixture), "--out", str(second)]).returncode == 0
+    size2 = second.stat().st_size
+
+    # And a third round.
+    assert _run([str(second), "pack", "--in", str(fixture), "--out", str(third)]).returncode == 0
+    size3 = third.stat().st_size
+
+    assert size1 == size2 == size3, (
+        f"binary grew across re-packs: {size1} -> {size2} -> {size3}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #7 -- truncating the trailing 1 KiB falls back to filesystem mode
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_bundle_falls_back_to_filesystem(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    bundled = tmp_path / "flapi-bundled"
+
+    assert _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(bundled)]).returncode == 0
+
+    # Sanity: bundle is present before truncation.
+    assert _run([str(bundled), "info"]).returncode == 0
+
+    # Chop 1 KiB off the end.
+    with bundled.open("r+b") as f:
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        assert size > 1024
+        f.truncate(size - 1024)
+
+    # `info` should now report no bundle (exit 1, "none" in output).
+    info_res = _run([str(bundled), "info"])
+    assert info_res.returncode == 1, f"truncated info exit={info_res.returncode}"
+    assert "none" in info_res.stdout, info_res.stdout
+
+    # Running it in --validate-config mode against an external fixture
+    # should still work (filesystem fallback, no crash).
+    val_res = _run(
+        [str(bundled), "--validate-config", "-c", str(fixture / "flapi.yaml")],
+    )
+    # Exit code 0 = clean validation, 1 = warnings-but-no-crash. Anything
+    # below 128 = no signal kill (139=SIGSEGV, 134=SIGABRT, etc).
+    assert val_res.returncode < 128, (
+        f"truncated binary crashed (exit {val_res.returncode}):\n"
+        f"stdout={val_res.stdout}\nstderr={val_res.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour #8 -- `flapi unpack` dumps the archive to a directory
+# ---------------------------------------------------------------------------
+
+
+def test_unpack_restores_all_entries(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    bundled = tmp_path / "flapi-bundled"
+    dst = tmp_path / "unpacked"
+
+    assert _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(bundled)]).returncode == 0
+
+    unpack_res = _run([str(bundled), "unpack", "--to", str(dst)])
+    assert unpack_res.returncode == 0, f"unpack failed: {unpack_res.stderr}"
+    assert "Unpacked" in unpack_res.stdout
+
+    # Every fixture file should be back.
+    assert (dst / "flapi.yaml").exists()
+    assert (dst / "sqls" / "hello.yaml").exists()
+    assert (dst / "sqls" / "hello.sql").exists()
+    assert (dst / "sqls" / "cities-embed.yaml").exists()
+    assert (dst / "sqls" / "cities-embed.sql").exists()
+    assert (dst / "data" / "cities.csv").exists()
+
+    # Bytes should match.
+    src_csv = (fixture / "data" / "cities.csv").read_bytes()
+    dst_csv = (dst / "data" / "cities.csv").read_bytes()
+    assert src_csv == dst_csv
+
+
+# ---------------------------------------------------------------------------
+# Pack rejects secret-looking files unless --allow-secrets
+# ---------------------------------------------------------------------------
+
+
+def test_pack_refuses_secret_files_by_default(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    (fixture / ".env").write_text("DB_PASSWORD=hunter2\n")
+    out = tmp_path / "flapi-bundled"
+
+    res = _run([str(_flapi()), "pack", "--in", str(fixture), "--out", str(out)])
+    assert res.returncode != 0
+    assert "secret" in res.stderr.lower() or "secret" in res.stdout.lower()
+    assert not out.exists() or out.stat().st_size == 0
+
+
+def test_pack_with_allow_secrets_bundles_env_files(tmp_path: pathlib.Path):
+    fixture = tmp_path / "fixture"
+    _write_fixture_tree(fixture)
+    (fixture / ".env").write_text("DB_PASSWORD=hunter2\n")
+    out = tmp_path / "flapi-bundled"
+
+    res = _run(
+        [str(_flapi()), "pack", "--in", str(fixture), "--out", str(out), "--allow-secrets"]
+    )
+    assert res.returncode == 0, f"--allow-secrets pack failed: {res.stderr}"
+    assert out.exists()
+
+    info = _run([str(out), "info"])
+    assert ".env" in info.stdout


### PR DESCRIPTION
Part of epic #40. **Stacked on #55** -> #54 -> #53 -> #52 -> #51.

## Summary

End-to-end integration tests against the real `flapi` binary,
covering the spike's documented round-trip behaviours. Plus an
implementation fix surfaced by the test for the secret deny list.

- New file: `test/integration/test_self_packaging.py` -- 8 tests,
  pytest, runs in ~24 s on Linux x86_64 debug build.
- Fix to `src/pack.cpp` -- validate input tree before copying the
  multi-GB host binary, so a rejected `.env` doesn't leave a
  half-written bundle on disk.

## Coverage map vs. the spike's 9 behaviours

| Spike # | Behaviour | This PR |
|---------|-----------|---------|
| 1 | filesystem mode serves endpoints                          | deferred -- existing tavern suite already covers filesystem-mode HTTP |
| 2 | `flapi pack` produces a bundled binary                    | ✅ `test_pack_produces_bundled_executable` |
| 3 | bundled binary serves endpoints from clean cwd            | deferred -- needs bundled-mode config-path resolution work |
| 4 | `flapi info` reports EOCD offset + entries                | ✅ `test_info_reports_bundle_contents` |
| 5 | self-hosting (bundled binary packs new bundled binary)    | ✅ `test_self_hosting_rebundle` |
| 6 | re-pack idempotence                                       | ✅ `test_repack_idempotence` (3 rounds) |
| 7 | 1-KiB-truncated bundle falls back to filesystem mode      | ✅ `test_truncated_bundle_falls_back_to_filesystem` |
| 8 | `flapi unpack` dumps the archive                          | ✅ `test_unpack_restores_all_entries` |
| 9 | `read_csv('embed://...')` in an endpoint template         | deferred -- in-process proof-of-life already in #54's unit tests |

Plus two non-spike invariants:
- `test_pack_refuses_secret_files_by_default` -- `.env` in input
  causes non-zero exit AND no half-written output binary.
- `test_pack_with_allow_secrets_bundles_env_files` -- `--allow-secrets`
  bypasses the deny list.

```
$ FLAPI_BUILD_TYPE=debug uv run pytest test_self_packaging.py -v
============================== 8 passed in 24.38s ==============================
```

## Why three behaviours are deferred

Behaviours #1, #3, #9 all need server-lifecycle test infrastructure
(subprocess start, health-wait, hit HTTP endpoints, teardown). #3 and
#9 additionally need the bundled binary to load its embedded config
when run from a clean cwd -- which depends on `ConfigManager`'s
template-path resolution behaving sensibly when the loaded config
came from `embed://flapi.yaml`. That's a non-trivial integration
question worth its own scope.

The DuckDB `read_csv('embed://...')` proof-of-life already runs
end-to-end in #54's unit tests against the in-process DuckDB
instance, so #9 is verified at the layer that matters most.
Filesystem-mode HTTP is exercised by every existing tavern test.

I'll file the server-lifecycle integration tests as a follow-up
issue once #51-#55 land.

## Implementation fix in src/pack.cpp

Before this PR, `Pack()` did:

```
1. copy 1.7 GB host bytes to <out>
2. walk input dir
3. throw PackError on .env
4. leave a 1.7 GB half-written file in the user's tmp dir
```

Re-ordered to:

```
1. walk input dir (validates against deny list)
2. write archive in memory
3. copy host bytes
4. append
```

Now `.env` rejection is fail-fast, no garbage left behind. The
`test_pack_refuses_secret_files_by_default` test enforces it.

## Test plan

- [x] All 8 tests pass locally (Linux x86_64, debug build).
- [x] Existing C++ unit tests still pass (no logic change beyond
      Pack() ordering, which is exercised by `test_pack_idempotence`
      and `test_pack_refuses_secret_files_by_default`).
- [ ] CI cross-platform once the whole stack lands (#56 covers that).

Closes #46 (partial -- server-lifecycle behaviours deferred to a
follow-up).