### PR TITLE
feat(self-packaging #65): ZIP64-sentinel WARN log in bundle_locator

### DIFF
--- a/src/bundle_locator.cpp
+++ b/src/bundle_locator.cpp
@@ -2,6 +2,8 @@
 #include "macho_bundle.hpp"
 #include "selfpath.hpp"
 
+#include <crow/logging.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <fstream>
@@ -63,6 +65,26 @@ std::optional<BundleLocation> ScanBufferForEocd(
 
         if (this_disk != 0 || cd_start_disk != 0) {
             continue;
+        }
+        // ZIP64 sentinels (#65): when a ZIP exceeds 4 GiB or 65535 entries,
+        // the EOCD's size / offset / entry-count fields are pinned to
+        // 0xffffffff / 0xffff and the real values live in a ZIP64 EOCD
+        // record we don't parse. Surface this explicitly -- the implicit
+        // range-check rejection below would otherwise return nullopt with
+        // no log line, making the failure indistinguishable from "no
+        // bundle present" in operator logs.
+        constexpr std::uint16_t kZip64SentinelU16 = 0xffffu;
+        constexpr std::uint32_t kZip64SentinelU32 = 0xffffffffu;
+        if (cd_size == kZip64SentinelU32 || cd_offset_arch == kZip64SentinelU32 ||
+            entries_this == kZip64SentinelU16 || entries_total == kZip64SentinelU16) {
+            CROW_LOG_WARNING
+                << "bundle_locator: ZIP64-shaped EOCD detected at file offset "
+                << (buf_start_in_file + i)
+                << " (cd_size=0x" << std::hex << cd_size
+                << " cd_offset=0x" << cd_offset_arch
+                << " entries=" << std::dec << entries_this
+                << "); ZIP64 is not supported -- treating as no bundle present";
+            return std::nullopt;
         }
         if (entries_this != entries_total) {
             continue;

--- a/test/cpp/bundle_locator_test.cpp
+++ b/test/cpp/bundle_locator_test.cpp
@@ -119,31 +119,66 @@ TEST_CASE("bundle_locator returns nullopt when no EOCD signature is present",
     REQUIRE_FALSE(loc.has_value());
 }
 
-TEST_CASE("bundle_locator rejects an EOCD with implausible fields", "[bundle_locator]") {
+namespace {
+
+// Helpers for building a synthetic EOCD record at the tail of a buffer.
+// Used by the ZIP64 sentinel tests; the EOCD layout is constant across
+// them and the existing tests would benefit from the same shorthand if
+// they ever need to grow.
+void PutU16(std::vector<std::uint8_t>& bytes, std::size_t off, std::uint16_t v) {
+    bytes[off] = static_cast<std::uint8_t>(v & 0xff);
+    bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
+}
+void PutU32(std::vector<std::uint8_t>& bytes, std::size_t off, std::uint32_t v) {
+    bytes[off]     = static_cast<std::uint8_t>(v & 0xff);
+    bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
+    bytes[off + 2] = static_cast<std::uint8_t>((v >> 16) & 0xff);
+    bytes[off + 3] = static_cast<std::uint8_t>((v >> 24) & 0xff);
+}
+
+}  // namespace
+
+TEST_CASE("bundle_locator rejects ZIP64-sentinel cd_size / cd_offset (issue #65)",
+          "[bundle_locator][zip64]") {
     // 2 KiB of filler with a fake EOCD signature at the very end whose
-    // central-directory size/offset can't possibly fit in the file.
+    // central-directory size/offset carry the ZIP64 sentinel 0xffffffff
+    // -- the marker that says "the real values live in a ZIP64 EOCD
+    // record". flapi does not parse ZIP64 records, so it must reject
+    // these as "no bundle present" rather than masquerading as malformed.
     std::vector<std::uint8_t> bytes(2048, std::uint8_t{0xab});
     const std::size_t eocd_off = bytes.size() - 22;
 
-    auto put_u16 = [&](std::size_t off, std::uint16_t v) {
-        bytes[off] = static_cast<std::uint8_t>(v & 0xff);
-        bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
-    };
-    auto put_u32 = [&](std::size_t off, std::uint32_t v) {
-        bytes[off]     = static_cast<std::uint8_t>(v & 0xff);
-        bytes[off + 1] = static_cast<std::uint8_t>((v >> 8) & 0xff);
-        bytes[off + 2] = static_cast<std::uint8_t>((v >> 16) & 0xff);
-        bytes[off + 3] = static_cast<std::uint8_t>((v >> 24) & 0xff);
-    };
+    PutU32(bytes, eocd_off + 0, 0x06054b50);   // signature
+    PutU16(bytes, eocd_off + 4, 0);             // disk number
+    PutU16(bytes, eocd_off + 6, 0);             // disk where CD starts
+    PutU16(bytes, eocd_off + 8, 1);             // entries on this disk
+    PutU16(bytes, eocd_off + 10, 1);            // total entries
+    PutU32(bytes, eocd_off + 12, 0xffffffffu);  // central directory size (ZIP64 sentinel)
+    PutU32(bytes, eocd_off + 16, 0xffffffffu);  // central directory offset (ZIP64 sentinel)
+    PutU16(bytes, eocd_off + 20, 0);            // comment length
 
-    put_u32(eocd_off + 0, 0x06054b50);   // signature
-    put_u16(eocd_off + 4, 0);             // disk number
-    put_u16(eocd_off + 6, 0);             // disk where CD starts
-    put_u16(eocd_off + 8, 1);             // entries on this disk
-    put_u16(eocd_off + 10, 1);            // total entries
-    put_u32(eocd_off + 12, 0xffffffffu);  // central directory size
-    put_u32(eocd_off + 16, 0xffffffffu);  // central directory offset
-    put_u16(eocd_off + 20, 0);            // comment length
+    TempBinary tb{bytes};
+    auto loc = LocateBundle(tb.path());
+    REQUIRE_FALSE(loc.has_value());
+}
+
+TEST_CASE("bundle_locator rejects ZIP64-sentinel entry counts (issue #65)",
+          "[bundle_locator][zip64]") {
+    // Same shape as above but the sentinel sits on the 16-bit entry-count
+    // fields (signals > 65535 entries). cd_size/cd_offset are kept
+    // plausible so they'd pass the range checks; the ZIP64 detection
+    // must catch the entry-count sentinel before then.
+    std::vector<std::uint8_t> bytes(2048, std::uint8_t{0xab});
+    const std::size_t eocd_off = bytes.size() - 22;
+
+    PutU32(bytes, eocd_off + 0, 0x06054b50);   // signature
+    PutU16(bytes, eocd_off + 4, 0);             // disk number
+    PutU16(bytes, eocd_off + 6, 0);             // disk where CD starts
+    PutU16(bytes, eocd_off + 8, 0xffffu);       // entries on this disk (ZIP64 sentinel)
+    PutU16(bytes, eocd_off + 10, 0xffffu);      // total entries (ZIP64 sentinel)
+    PutU32(bytes, eocd_off + 12, 64);           // central directory size (plausible)
+    PutU32(bytes, eocd_off + 16, 256);          // central directory offset (plausible)
+    PutU16(bytes, eocd_off + 20, 0);            // comment length
 
     TempBinary tb{bytes};
     auto loc = LocateBundle(tb.path());


### PR DESCRIPTION
## Summary

Follow-up to the narrowing comment on #65. The defensive rejection of
ZIP64-sentinel-shaped EOCDs was already in place via the implicit
range checks at \`src/bundle_locator.cpp:89-94\`, but the failure
returned \`nullopt\` with no log line -- indistinguishable from
"no bundle present" in operator output.

This PR makes the ZIP64 case explicit:

- Detects the sentinel values (\`cd_size == 0xffffffff\`,
  \`cd_offset == 0xffffffff\`, \`entries_this == 0xffff\`, or
  \`entries_total == 0xffff\`) inside the EOCD scan loop, after the
  disk-number sanity checks.
- Emits a single-line \`CROW_LOG_WARNING\` naming the mismatch and the
  offending field values, so an operator who packed a > 4 GiB or
  > 65535-entry tree sees *why* their bundle isn't being recognised.
- Returns \`nullopt\` early instead of falling through to the implicit
  range-check rejection.

Full ZIP64 EOCD locator (\`0x06064b50\`) + ZIP64 EOCD record parsing is
deliberately not implemented -- config bundles will never approach
4 GiB, and the WARN log gives operators enough signal to act.

## Changes

- \`src/bundle_locator.cpp\`: explicit ZIP64 sentinel check + WARN log
  + early \`return std::nullopt\`. Adds \`<crow/logging.h>\` include
  (other src/ files like \`credential_manager.cpp\` use the same
  header for the same purpose).
- \`test/cpp/bundle_locator_test.cpp\`:
  - Renames the existing test "rejects an EOCD with implausible
    fields" to "rejects ZIP64-sentinel cd_size / cd_offset
    (issue #65)" and adds the \`[zip64]\` tag.
  - Adds a second test "rejects ZIP64-sentinel entry counts
    (issue #65)" exercising the 16-bit entry-count sentinel
    (\`0xffff\`) with otherwise-plausible cd_size/cd_offset --
    a case the existing range-check rejection would have missed.
  - Factors out shared \`PutU16\` / \`PutU32\` helpers in an anonymous
    namespace.

## Test plan

- [x] \`ctest\` — 638 / 638 pass serially (5 → 6 bundle_locator
  tests; the new tag \`[zip64]\` picks up both ZIP64 cases)
- [x] \`ctest -R \"bundle_locator|zip64\"\` — 6 / 6 pass

Closes #65.