### PR TITLE
feat(resources #71): cgroup-aware resource-limit observability + regression guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ add_library(flapi-lib STATIC
     src/sql_parameter_classifier.cpp
     src/sql_template_processor.cpp
     src/sql_utils.cpp
+    src/system_resources.cpp
     src/mcp_server.cpp
     src/mcp_tool_handler.cpp
     src/mcp_tool_rate_limiter.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for flAPI project
 
 # Phony targets
-.PHONY: all debug release clean run-debug run-release run-integration-tests docker-build web cli-build cli-test vscode-build vscode-dev integration-test integration-tests integration-test-rest integration-test-mcp integration-test-ducklake integration-test-examples integration-test-setup integration-test-ci test-all help
+.PHONY: all debug release clean run-debug run-release run-integration-tests docker-build web cli-build cli-test vscode-build vscode-dev integration-test integration-tests integration-test-rest integration-test-mcp integration-test-ducklake integration-test-examples integration-test-setup integration-test-ci smoke-test-resources test-all help
 
 # Check if Ninja is available
 NINJA := $(shell which ninja)
@@ -308,6 +308,13 @@ integration-test-ci: release integration-test-setup
 	wait $$SERVER_PID 2>/dev/null || true; \
 	echo "Integration tests completed with exit code: $$TEST_RESULT"; \
 	exit $$TEST_RESULT
+
+# Container smoke test for cgroup-aware memory sizing (#71).
+# Runs the release binary in a memory-limited Docker container and asserts
+# DuckDB honors the cgroup limit (graceful OOM, server survives). Skips on
+# non-Linux / no-Docker hosts. See test/integration/smoke_resource_limits.sh.
+smoke-test-resources: release
+	@bash test/integration/smoke_resource_limits.sh
 
 # Build Docker image
 docker: release

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -300,8 +300,16 @@ duckdb:
 **Notes:**
 - Omit `db_path` or set to `:memory:` for an in-memory database
 - Any key-value pairs are passed directly as DuckDB settings
+- **Containers (cgroup limits):** when `threads`/`max_memory` are omitted (the
+  default), DuckDB sizes them from the container's cgroup limits — `max_memory`
+  to ~80% of the cgroup memory limit and `threads` from the CPU quota (Kubernetes
+  limits, Docker `--memory`/`--cpus`, etc.). You normally do **not** need to set
+  these per deployment target. To pin explicit values, set them here and they are
+  passed straight through. flAPI logs the detected ceiling at startup as
+  `resource-limits: memory source=cgroup-v2 available=...MB` / `cpu source=...`,
+  so the limit it is actually running under is visible in the logs (#71).
 
-> **Implementation:** `src/database_manager.cpp` | **Tests:** `test/cpp/database_manager_test.cpp`
+> **Implementation:** `src/database_manager.cpp`, `src/system_resources.cpp` | **Tests:** `test/cpp/database_manager_test.cpp`, `test/cpp/system_resources_test.cpp`
 
 ### 2.5 DuckLake Configuration
 

--- a/docs/spec/DESIGN_DECISIONS.md
+++ b/docs/spec/DESIGN_DECISIONS.md
@@ -416,6 +416,47 @@ four supported platforms (#49 / `.github/workflows/build.yaml`).
 
 ---
 
+## 10. Container memory/CPU limits: rely on DuckDB's cgroup awareness (#71)
+
+**Decision:** Do **not** add a flApi-side mechanism to size `max_memory` /
+`threads` from container cgroup limits. Instead, rely on DuckDB's own
+cgroup-aware detection and simply **log the detected limits at startup** for
+observability.
+
+**Context:** Issue #71 proposed an opt-in `--auto-memory` flag, on the premise
+that DuckDB reads *host* RAM (via `/proc/meminfo`, `sysconf`) and ignores
+container cgroup limits — so an unbounded buffer pool inside a small container
+would be kernel-OOM-killed (exit 137) rather than failing gracefully.
+
+**Finding (empirically verified, DuckDB 1.5.2):** that premise no longer holds.
+Running the binary in memory/CPU-limited containers shows DuckDB **already**
+honors cgroup limits:
+
+| Container limit | DuckDB `memory_limit` (no config) | DuckDB `threads` (no config) |
+|---|---|---|
+| `--memory=512m` | 409.5 MiB (≈80% of cgroup) | — |
+| `--memory=1g --cpus=2` | 819 MiB (≈80% of cgroup) | 2 (from CPU quota) |
+
+A ~3 GiB query in a 1 GiB container raises a **graceful** DuckDB "Out of Memory"
+error and the server survives — no kernel kill. (The `using 32 threads` startup
+line is Crow's HTTP thread pool, not DuckDB query parallelism — a red herring.)
+
+**Consequences:**
+- A flApi-side override would, at best, duplicate DuckDB's behavior; its only
+  unique value would be a tunable percentage (DuckDB hardcodes ~80%). That did
+  not justify the cross-platform detection/precedence surface area, so it was
+  dropped.
+- `src/system_resources.{hpp,cpp}` provides cgroup v1/v2 memory + CPU detection
+  (unit-tested with injectable `/sys/fs/cgroup` roots) used **only** to emit a
+  startup `resource-limits:` INFO log, so the ceiling flApi runs under is
+  visible and container misconfiguration is diagnosable.
+- **To override** the defaults, set `duckdb.max_memory` / `duckdb.threads`
+  explicitly in `flapi.yaml` (these are passed straight through to DuckDB).
+- `test/integration/smoke_resource_limits.sh` (`make smoke-test-resources`) is a
+  Docker regression guard asserting the graceful-degradation behavior.
+
+---
+
 ## Summary
 
 These design decisions prioritize:

--- a/src/database_manager.cpp
+++ b/src/database_manager.cpp
@@ -12,6 +12,7 @@
 #include "sql_utils.hpp"
 #include "database_manager.hpp"
 #include "duckdb_raii.hpp"
+#include "system_resources.hpp"
 
 namespace flapi {
 
@@ -259,13 +260,50 @@ void DatabaseManager::createAndInitializeDuckDBConfig(std::shared_ptr<ConfigMana
         throw std::runtime_error("Failed to set DuckDB configuration: autoload_known_extensions");
     }
 
-    // Apply settings from the configuration
+    // Observability (#71): log the memory / CPU limits we detect for this
+    // process (honoring container cgroup limits). This does NOT change any
+    // DuckDB setting -- DuckDB 1.5.2 is itself cgroup-aware and sizes
+    // max_memory (~80% of the limit) and threads from the same limits. The
+    // log makes container misconfiguration diagnosable and lets operators see
+    // the ceiling flAPI is actually running under. To override, set
+    // duckdb.max_memory / duckdb.threads explicitly in flapi.yaml.
+    logDetectedResourceLimits(config_manager);
+
+    // Apply settings from the configuration.
     const auto& duckdb_settings = config_manager->getDuckDBConfig().settings;
     for (const auto& [key, value] : duckdb_settings) {
         if (duckdb_set_config(config, key.c_str(), value.c_str()) == DuckDBError) {
             duckdb_destroy_config(&config);
             throw std::runtime_error("Failed to set DuckDB configuration: " + key);
         }
+    }
+}
+
+void DatabaseManager::logDetectedResourceLimits(std::shared_ptr<ConfigManager> config_manager) {
+    const auto& settings = config_manager->getDuckDBConfig().settings;
+
+    flapi::MemoryDetection mem = flapi::DetectAvailableMemoryBytes();
+    if (mem.source != "unknown" && mem.bytes > 0) {
+        CROW_LOG_INFO << "resource-limits: memory source=" << mem.source
+                      << " available=" << (mem.bytes / (1024ull * 1024ull)) << "MB"
+                      << (settings.count("max_memory") > 0
+                              ? " (overridden by duckdb.max_memory=" + settings.at("max_memory") + ")"
+                              : " (DuckDB sizes max_memory from this limit)");
+    } else {
+        CROW_LOG_DEBUG << "resource-limits: could not detect a memory limit; "
+                       << "DuckDB will use its own detection.";
+    }
+
+    flapi::CpuDetection cpu = flapi::DetectAvailableCpuCount();
+    if (cpu.source != "unknown" && cpu.cores >= 1) {
+        CROW_LOG_INFO << "resource-limits: cpu source=" << cpu.source
+                      << " cores=" << cpu.cores
+                      << (settings.count("threads") > 0
+                              ? " (overridden by duckdb.threads=" + settings.at("threads") + ")"
+                              : " (DuckDB sizes threads from this limit)");
+    } else {
+        CROW_LOG_DEBUG << "resource-limits: could not detect a CPU quota; "
+                       << "DuckDB will use its own detection.";
     }
 }
 

--- a/src/include/database_manager.hpp
+++ b/src/include/database_manager.hpp
@@ -100,7 +100,12 @@ private:
     void logDuckDBVersion();
     
     void createAndInitializeDuckDBConfig(std::shared_ptr<ConfigManager> config_manager, duckdb_config& config);
-   
+
+    // Observability (#71): log the cgroup-detected memory / CPU limits at
+    // startup. Does not change any DuckDB setting (DuckDB is itself
+    // cgroup-aware); purely diagnostic so the running ceiling is visible.
+    void logDetectedResourceLimits(std::shared_ptr<ConfigManager> config_manager);
+
 
     std::string processTemplate(const EndpointConfig& endpoint, std::map<std::string, std::string>& params);
     std::string processCacheTemplate(const EndpointConfig& endpoint, const CacheConfig& cacheConfig, std::map<std::string, std::string>& params);

--- a/src/include/system_resources.hpp
+++ b/src/include/system_resources.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace flapi {
+
+// Result of probing the memory available to this process. `bytes` is the
+// detected ceiling (cgroup limit or host physical memory, whichever is
+// smaller); `source` names where the value came from so it can be logged.
+// On failure `bytes == 0` and `source == "unknown"`.
+struct MemoryDetection {
+    uint64_t bytes = 0;
+    std::string source = "unknown"; // cgroup-v2|cgroup-v1|meminfo|sysconf|sysctl|win-global|unknown
+};
+
+// Result of probing the CPU quota available to this process. `cores` is
+// clamped to at least 1 when a positive value is detected.
+struct CpuDetection {
+    uint32_t cores = 0;
+    std::string source = "unknown"; // cgroup-v2|cgroup-v1|hardware|unknown
+};
+
+// --- Pure parsers (no filesystem; unit-tested directly) ------------------
+
+// cgroup v2 `memory.max`. A literal "max" means unlimited -> nullopt.
+std::optional<uint64_t> ParseCgroupV2MemoryMax(const std::string& content);
+
+// cgroup v1 `memory.limit_in_bytes`. Absurdly large sentinel values
+// (PAGE_COUNTER_MAX, 0x7FFFFFFFFFFFF000, etc.) mean unlimited -> nullopt.
+std::optional<uint64_t> ParseCgroupV1MemoryLimit(const std::string& content);
+
+// cgroup v2 `cpu.max` == "<quota> <period>". "max ..." means unlimited ->
+// nullopt. Otherwise effective cores = ceil(quota / period), clamped >= 1.
+std::optional<uint32_t> ParseCgroupV2CpuMax(const std::string& content);
+
+// cgroup v1 `cpu.cfs_quota_us` / `cpu.cfs_period_us`. quota -1 means
+// unlimited -> nullopt. Otherwise ceil(quota / period), clamped >= 1.
+std::optional<uint32_t> ParseCgroupV1Cpu(const std::string& quota, const std::string& period);
+
+// --- Composing detectors (probe filesystem; `root` is injectable for tests) ---
+
+MemoryDetection DetectAvailableMemoryBytes(const std::string& root = "/");
+CpuDetection DetectAvailableCpuCount(const std::string& root = "/");
+
+} // namespace flapi

--- a/src/system_resources.cpp
+++ b/src/system_resources.cpp
@@ -1,0 +1,289 @@
+#include "system_resources.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+#if defined(__linux__)
+#include <unistd.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace flapi {
+
+namespace {
+
+std::string trim(const std::string& s) {
+    size_t begin = 0;
+    size_t end = s.size();
+    while (begin < end && std::isspace(static_cast<unsigned char>(s[begin]))) {
+        ++begin;
+    }
+    while (end > begin && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
+        --end;
+    }
+    return s.substr(begin, end - begin);
+}
+
+// Read an entire file under `root`. Returns nullopt if it does not exist.
+std::optional<std::string> readFile(const std::string& root, const std::string& relpath) {
+    std::string path = root;
+    if (!path.empty() && path.back() == '/' && !relpath.empty() && relpath.front() == '/') {
+        path.pop_back();
+    } else if (!path.empty() && path.back() != '/' && !relpath.empty() && relpath.front() != '/') {
+        path += '/';
+    }
+    path += relpath;
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return std::nullopt;
+    }
+    std::stringstream ss;
+    ss << file.rdbuf();
+    return ss.str();
+}
+
+// Any cgroup memory limit at or above this is treated as "unlimited". This
+// covers PAGE_COUNTER_MAX and the various INT64/page-aligned sentinels used by
+// cgroup v1, and guards against absurd values exceeding physical RAM.
+constexpr uint64_t kUnlimitedThreshold = 0x7000000000000000ull;
+
+uint64_t hostPhysicalBytes(const std::string& root) {
+    // Prefer /proc/meminfo MemTotal (works with an injected root in tests);
+    // fall back to sysconf on the real system.
+    if (auto meminfo = readFile(root, "proc/meminfo")) {
+        std::istringstream iss(*meminfo);
+        std::string line;
+        while (std::getline(iss, line)) {
+            if (line.rfind("MemTotal:", 0) == 0) {
+                std::istringstream ls(line.substr(std::string("MemTotal:").size()));
+                uint64_t kb = 0;
+                std::string unit;
+                ls >> kb >> unit;
+                if (kb > 0) {
+                    return kb * 1024ull;
+                }
+            }
+        }
+    }
+#if defined(__linux__)
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    if (pages > 0 && page_size > 0) {
+        return static_cast<uint64_t>(pages) * static_cast<uint64_t>(page_size);
+    }
+#endif
+    return 0;
+}
+
+} // namespace
+
+std::optional<uint64_t> ParseCgroupV2MemoryMax(const std::string& content) {
+    std::string s = trim(content);
+    if (s.empty() || s == "max") {
+        return std::nullopt;
+    }
+    try {
+        size_t consumed = 0;
+        uint64_t value = std::stoull(s, &consumed);
+        if (consumed != s.size() || value == 0 || value >= kUnlimitedThreshold) {
+            return std::nullopt;
+        }
+        return value;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<uint64_t> ParseCgroupV1MemoryLimit(const std::string& content) {
+    std::string s = trim(content);
+    if (s.empty()) {
+        return std::nullopt;
+    }
+    try {
+        size_t consumed = 0;
+        uint64_t value = std::stoull(s, &consumed);
+        if (consumed != s.size() || value == 0 || value >= kUnlimitedThreshold) {
+            return std::nullopt;
+        }
+        return value;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+namespace {
+
+std::optional<uint32_t> coresFromQuotaPeriod(int64_t quota, int64_t period) {
+    if (quota <= 0 || period <= 0) {
+        return std::nullopt;
+    }
+    // ceil(quota / period), clamped to >= 1.
+    int64_t cores = (quota + period - 1) / period;
+    if (cores < 1) {
+        cores = 1;
+    }
+    return static_cast<uint32_t>(cores);
+}
+
+} // namespace
+
+std::optional<uint32_t> ParseCgroupV2CpuMax(const std::string& content) {
+    std::istringstream iss(trim(content));
+    std::string quota_str;
+    int64_t period = 0;
+    if (!(iss >> quota_str >> period)) {
+        return std::nullopt;
+    }
+    if (quota_str == "max") {
+        return std::nullopt;
+    }
+    try {
+        int64_t quota = std::stoll(quota_str);
+        return coresFromQuotaPeriod(quota, period);
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<uint32_t> ParseCgroupV1Cpu(const std::string& quota, const std::string& period) {
+    try {
+        int64_t q = std::stoll(trim(quota));
+        int64_t p = std::stoll(trim(period));
+        if (q < 0) { // -1 means unlimited
+            return std::nullopt;
+        }
+        return coresFromQuotaPeriod(q, p);
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+MemoryDetection DetectAvailableMemoryBytes(const std::string& root) {
+    MemoryDetection result;
+    uint64_t host = hostPhysicalBytes(root);
+
+    auto bound = [&](uint64_t cgroup_value, const std::string& source) -> bool {
+        uint64_t value = cgroup_value;
+        if (host > 0) {
+            value = std::min(value, host); // never exceed physical RAM
+        }
+        result.bytes = value;
+        result.source = source;
+        return true;
+    };
+
+#if defined(__linux__) || defined(FLAPI_FORCE_CGROUP_PROBE)
+    // cgroup v2
+    if (auto content = readFile(root, "sys/fs/cgroup/memory.max")) {
+        if (auto v = ParseCgroupV2MemoryMax(*content)) {
+            bound(*v, "cgroup-v2");
+            return result;
+        }
+        // memory.max == "max": honor memory.high soft limit if present.
+        if (auto high = readFile(root, "sys/fs/cgroup/memory.high")) {
+            if (auto hv = ParseCgroupV2MemoryMax(*high)) {
+                bound(*hv, "cgroup-v2");
+                return result;
+            }
+        }
+    }
+    // cgroup v1
+    if (auto content = readFile(root, "sys/fs/cgroup/memory/memory.limit_in_bytes")) {
+        if (auto v = ParseCgroupV1MemoryLimit(*content)) {
+            bound(*v, "cgroup-v1");
+            return result;
+        }
+    }
+#endif
+
+    if (host > 0) {
+        result.bytes = host;
+        result.source = "meminfo";
+        return result;
+    }
+
+#if defined(__APPLE__)
+    {
+        uint64_t memsize = 0;
+        size_t len = sizeof(memsize);
+        if (sysctlbyname("hw.memsize", &memsize, &len, nullptr, 0) == 0 && memsize > 0) {
+            result.bytes = memsize;
+            result.source = "sysctl";
+            return result;
+        }
+    }
+#elif defined(_WIN32)
+    {
+        MEMORYSTATUSEX status;
+        status.dwLength = sizeof(status);
+        if (GlobalMemoryStatusEx(&status) && status.ullTotalPhys > 0) {
+            result.bytes = status.ullTotalPhys;
+            result.source = "win-global";
+            return result;
+        }
+    }
+#endif
+
+    return result; // bytes == 0, source == "unknown"
+}
+
+CpuDetection DetectAvailableCpuCount(const std::string& root) {
+    CpuDetection result;
+    uint32_t hw = std::thread::hardware_concurrency();
+
+    auto finalize = [&](uint32_t cores, const std::string& source) {
+        if (hw > 0) {
+            cores = std::min(cores, hw);
+        }
+        if (cores < 1) {
+            cores = 1;
+        }
+        result.cores = cores;
+        result.source = source;
+    };
+
+#if defined(__linux__) || defined(FLAPI_FORCE_CGROUP_PROBE)
+    // cgroup v2
+    if (auto content = readFile(root, "sys/fs/cgroup/cpu.max")) {
+        if (auto v = ParseCgroupV2CpuMax(*content)) {
+            finalize(*v, "cgroup-v2");
+            return result;
+        }
+    }
+    // cgroup v1
+    {
+        auto quota = readFile(root, "sys/fs/cgroup/cpu/cpu.cfs_quota_us");
+        auto period = readFile(root, "sys/fs/cgroup/cpu/cpu.cfs_period_us");
+        if (quota && period) {
+            if (auto v = ParseCgroupV1Cpu(*quota, *period)) {
+                finalize(*v, "cgroup-v1");
+                return result;
+            }
+        }
+    }
+#endif
+
+    if (hw > 0) {
+        result.cores = hw;
+        result.source = "hardware";
+        return result;
+    }
+
+    result.cores = 1;
+    result.source = "hardware";
+    return result;
+}
+
+} // namespace flapi

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(flapi_tests
     sql_parameter_classifier_test.cpp
     sql_template_processor_test.cpp
     sql_utils_test.cpp
+    system_resources_test.cpp
     test_duckdb_raii.cpp
     test_json_utils.cpp
     test_config_loader.cpp

--- a/test/cpp/system_resources_test.cpp
+++ b/test/cpp/system_resources_test.cpp
@@ -1,0 +1,129 @@
+#include <catch2/catch_test_macros.hpp>
+#include "system_resources.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace flapi;
+
+namespace {
+
+constexpr uint64_t kGiB = 1024ull * 1024ull * 1024ull;
+constexpr uint64_t kMiB = 1024ull * 1024ull;
+
+// Write `content` to `<root>/<relpath>`, creating parent dirs.
+void writeUnder(const std::filesystem::path& root, const std::string& relpath,
+                const std::string& content) {
+    std::filesystem::path full = root / relpath;
+    std::filesystem::create_directories(full.parent_path());
+    std::ofstream file(full);
+    file << content;
+}
+
+std::filesystem::path makeTempRoot(const std::string& name) {
+    std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("flapi_sysres_" + name);
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    return root;
+}
+
+} // namespace
+
+TEST_CASE("ParseCgroupV2MemoryMax", "[system_resources]") {
+    SECTION("numeric value") {
+        auto v = ParseCgroupV2MemoryMax("2147483648\n");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 2ull * kGiB);
+    }
+    SECTION("literal max is unlimited") {
+        REQUIRE_FALSE(ParseCgroupV2MemoryMax("max\n").has_value());
+    }
+    SECTION("garbage is unlimited/ignored") {
+        REQUIRE_FALSE(ParseCgroupV2MemoryMax("").has_value());
+        REQUIRE_FALSE(ParseCgroupV2MemoryMax("not-a-number").has_value());
+    }
+}
+
+TEST_CASE("ParseCgroupV1MemoryLimit", "[system_resources]") {
+    SECTION("normal value") {
+        auto v = ParseCgroupV1MemoryLimit("536870912\n"); // 512 MiB
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 512ull * kMiB);
+    }
+    SECTION("PAGE_COUNTER_MAX sentinel is unlimited") {
+        REQUIRE_FALSE(ParseCgroupV1MemoryLimit("9223372036854771712").has_value());
+    }
+    SECTION("0x7FFF... sentinel is unlimited") {
+        REQUIRE_FALSE(ParseCgroupV1MemoryLimit("9223372036854775807").has_value());
+    }
+}
+
+TEST_CASE("ParseCgroupV2CpuMax", "[system_resources]") {
+    SECTION("exact multiple") {
+        auto v = ParseCgroupV2CpuMax("200000 100000");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 2);
+    }
+    SECTION("rounds up") {
+        auto v = ParseCgroupV2CpuMax("150000 100000");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 2);
+    }
+    SECTION("sub-core rounds up to 1") {
+        auto v = ParseCgroupV2CpuMax("50000 100000");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 1);
+    }
+    SECTION("max is unlimited") {
+        REQUIRE_FALSE(ParseCgroupV2CpuMax("max 100000").has_value());
+    }
+}
+
+TEST_CASE("ParseCgroupV1Cpu", "[system_resources]") {
+    SECTION("two cores") {
+        auto v = ParseCgroupV1Cpu("200000", "100000");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 2);
+    }
+    SECTION("quota -1 is unlimited") {
+        REQUIRE_FALSE(ParseCgroupV1Cpu("-1", "100000").has_value());
+    }
+    SECTION("rounds up") {
+        auto v = ParseCgroupV1Cpu("250000", "100000");
+        REQUIRE(v.has_value());
+        REQUIRE(*v == 3);
+    }
+}
+
+TEST_CASE("DetectAvailableMemoryBytes honors cgroup v2", "[system_resources]") {
+    auto root = makeTempRoot("memv2");
+    // 512 MiB -- comfortably below any real host, so min(cgroup,host)==cgroup.
+    writeUnder(root, "sys/fs/cgroup/memory.max", "536870912\n");
+
+    auto det = DetectAvailableMemoryBytes(root.string());
+    REQUIRE(det.source == "cgroup-v2");
+    REQUIRE(det.bytes == 512ull * kMiB);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("DetectAvailableMemoryBytes falls through unlimited cgroup v2", "[system_resources]") {
+    auto root = makeTempRoot("memv2max");
+    writeUnder(root, "sys/fs/cgroup/memory.max", "max\n");
+    // No v1, no meminfo under this root: detector should report a host value or
+    // unknown, but never the bogus cgroup value.
+    auto det = DetectAvailableMemoryBytes(root.string());
+    REQUIRE(det.source != "cgroup-v2");
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("DetectAvailableCpuCount honors cgroup v2", "[system_resources]") {
+    auto root = makeTempRoot("cpuv2");
+    writeUnder(root, "sys/fs/cgroup/cpu.max", "200000 100000");
+    auto det = DetectAvailableCpuCount(root.string());
+    REQUIRE(det.source == "cgroup-v2");
+    REQUIRE(det.cores == 2);
+    std::filesystem::remove_all(root);
+}

--- a/test/integration/smoke/flapi.yaml
+++ b/test/integration/smoke/flapi.yaml
@@ -1,0 +1,24 @@
+# Smoke-test configuration for container memory-limit behavior (#71).
+#
+# Deliberately does NOT set duckdb.max_memory or duckdb.threads, so DuckDB's
+# own cgroup-aware detection sizes them from the container's limit. In-memory
+# DuckDB with no temp_directory, so the memory-pressure query in
+# sqls/memtest.sql cannot spill to disk and exercises the buffer-pool limit.
+project-name: flapi-resource-limit-smoke
+project-description: Container smoke test for cgroup-aware memory sizing
+
+template:
+  path: './sqls'
+
+connections:
+  mem:
+    properties: {}
+    allow: '*'
+
+# In-memory DuckDB; intentionally no max_memory / threads (auto-memory fills them).
+duckdb:
+  access_mode: READ_WRITE
+
+# No DuckLake / caching -- keep startup trivial and fully in-memory.
+mcp:
+  enabled: false

--- a/test/integration/smoke/sqls/health.sql
+++ b/test/integration/smoke/sqls/health.sql
@@ -1,0 +1,2 @@
+-- Liveness probe for the auto-memory smoke test (#71).
+SELECT 1 AS ok

--- a/test/integration/smoke/sqls/health.yaml
+++ b/test/integration/smoke/sqls/health.yaml
@@ -1,0 +1,10 @@
+# Liveness endpoint for the auto-memory smoke test (#71).
+url-path: /health/
+method: GET
+
+template-source: health.sql
+connection:
+  - mem
+
+auth:
+  enabled: false

--- a/test/integration/smoke/sqls/memtest.sql
+++ b/test/integration/smoke/sqls/memtest.sql
@@ -1,0 +1,18 @@
+-- Memory-pressure probe for the auto-memory smoke test (#71).
+--
+-- Builds one large string_agg in a SINGLE aggregate group. A single-group
+-- string aggregate cannot spill to disk, so it forces DuckDB to allocate the
+-- whole buffer against its memory pool:
+--   * auto-memory ON  -> max_memory is sized to the cgroup limit, so DuckDB
+--     raises a graceful "Out of Memory" error well below the container ceiling
+--     and the server process survives.
+--   * auto-memory OFF -> max_memory defaults to (host) RAM, DuckDB allocates
+--     past the cgroup limit, and the kernel OOM-kills the process (exit 137).
+--
+-- `rows` defaults to 3,000,000 (~3 GiB of 1000-char strings), comfortably above
+-- a 1 GiB container limit and an 80%-of-1GiB (~800 MiB) max_memory.
+SELECT length(string_agg(s, ',')) AS total_len
+FROM (
+  SELECT repeat('x', 1000) AS s
+  FROM range({{#params.rows}}{{ params.rows }}{{/params.rows}}{{^params.rows}}3000000{{/params.rows}})
+) t

--- a/test/integration/smoke/sqls/memtest.yaml
+++ b/test/integration/smoke/sqls/memtest.yaml
@@ -1,0 +1,20 @@
+# Memory-pressure endpoint for the auto-memory smoke test (#71).
+url-path: /memtest/
+method: GET
+
+request:
+  - field-name: rows
+    field-in: query
+    description: Number of 1000-char rows to aggregate (memory pressure knob)
+    required: false
+    validators:
+      - type: int
+        min: 1
+        max: 100000000
+
+template-source: memtest.sql
+connection:
+  - mem
+
+auth:
+  enabled: false

--- a/test/integration/smoke_resource_limits.sh
+++ b/test/integration/smoke_resource_limits.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Container smoke test for cgroup-aware memory sizing (#71).
+#
+# Background: issue #71 assumed DuckDB sizes max_memory from *host* RAM and
+# ignores cgroup limits, so a memory-heavy query inside a small container would
+# blow past the limit and get kernel-OOM-killed (exit 137). Empirically, the
+# bundled DuckDB (1.5.2) is ALREADY cgroup-aware: it sizes max_memory to ~80%
+# of the cgroup memory limit and threads to the CPU quota. So the kernel-OOM
+# "red" cannot be reproduced -- DuckDB prevents it upstream.
+#
+# This test therefore asserts the *good* behavior as a regression guard: a
+# ~3 GiB query in a 1 GiB container fails with a GRACEFUL DuckDB "Out of
+# Memory" error (HTTP 500) and the server SURVIVES (would be exit 137 / gone if
+# DuckDB ever stopped honoring the cgroup limit). It also asserts flAPI's
+# startup `resource-limits:` log reports the cgroup-detected ceiling.
+#
+# Requirements: Linux + Docker. Skips (exit 0) if either is unavailable.
+#
+# Tunables (env):
+#   FLAPI_SMOKE_BINARY  path to a linux flapi binary   (default: build/release/flapi)
+#   FLAPI_SMOKE_IMAGE   base image to run it in        (default: ubuntu:24.04)
+#   FLAPI_SMOKE_MEM     container memory limit         (default: 1g)
+#   FLAPI_SMOKE_ROWS    memory-pressure row count      (default: 3000000)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+BINARY="${FLAPI_SMOKE_BINARY:-${REPO_ROOT}/build/release/flapi}"
+IMAGE="${FLAPI_SMOKE_IMAGE:-ubuntu:24.04}"
+MEM="${FLAPI_SMOKE_MEM:-1g}"
+ROWS="${FLAPI_SMOKE_ROWS:-3000000}"
+CONFIG_DIR="${SCRIPT_DIR}/smoke"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YEL='\033[0;33m'; NC='\033[0m'
+info()  { echo -e "${YEL}[smoke]${NC} $*"; }
+pass()  { echo -e "${GREEN}[PASS]${NC} $*"; }
+fail()  { echo -e "${RED}[FAIL]${NC} $*"; }
+skip()  { echo -e "${YEL}[SKIP]${NC} $*"; exit 0; }
+
+# --- preflight ------------------------------------------------------------
+[ "$(uname -s)" = "Linux" ]      || skip "not Linux (uname=$(uname -s)); cgroup memory limits are Linux-only"
+command -v docker >/dev/null 2>&1 || skip "docker not found on PATH"
+docker info >/dev/null 2>&1       || skip "docker daemon not reachable"
+[ -x "${BINARY}" ]                || { fail "flapi binary not found/executable: ${BINARY} (build with 'make release')"; exit 1; }
+
+if ! docker run --rm -v "${BINARY}:/app/flapi:ro" "${IMAGE}" /app/flapi --version >/dev/null 2>&1; then
+    skip "binary ${BINARY} cannot run in ${IMAGE} (likely glibc mismatch); set FLAPI_SMOKE_IMAGE to a compatible base or FLAPI_SMOKE_BINARY to a CI-built linux binary"
+fi
+
+CID=""
+cleanup() { [ -n "${CID}" ] && docker rm -f "${CID}" >/dev/null 2>&1; }
+trap cleanup EXIT
+
+info "Starting flAPI in a --memory=${MEM} container (no explicit max_memory)..."
+CID="$(docker run -d --rm \
+    --memory="${MEM}" --memory-swap="${MEM}" \
+    -v "${BINARY}:/app/flapi:ro" \
+    -v "${CONFIG_DIR}:/cfg:ro" \
+    -p 127.0.0.1:0:8080 \
+    "${IMAGE}" \
+    /app/flapi -c /cfg/flapi.yaml -p 8080 --host 0.0.0.0 --log-level info)"
+
+PORT="$(docker port "${CID}" 8080/tcp 2>/dev/null | head -n1 | sed 's/.*://')"
+
+healthy=0
+for _ in $(seq 1 60); do
+    if curl -sf --max-time 3 "http://127.0.0.1:${PORT}/health/" >/dev/null 2>&1; then healthy=1; break; fi
+    sleep 0.5
+done
+if [ "${healthy}" -ne 1 ]; then
+    fail "server never became healthy"; docker logs "${CID}" 2>&1 | tail -20; exit 1
+fi
+
+rc=0
+
+# (1) startup log reports the cgroup-detected limit
+LOGS="$(docker logs "${CID}" 2>&1)"
+if echo "${LOGS}" | grep -qE 'resource-limits: memory source=cgroup'; then
+    pass "startup log reports cgroup-detected memory limit"
+    echo "${LOGS}" | grep -E 'resource-limits:' | sed 's/^/        /'
+else
+    fail "startup log missing 'resource-limits: memory source=cgroup...'"
+    echo "${LOGS}" | tail -20; rc=1
+fi
+
+# (2) memory-heavy query degrades gracefully and the server survives
+info "Firing ~3 GiB memory bomb (rows=${ROWS}) into a ${MEM} container..."
+BODY="$(curl -s --max-time 90 "http://127.0.0.1:${PORT}/memtest/?rows=${ROWS}" 2>/dev/null || true)"
+HEALTH="$(curl -s -o /dev/null --max-time 5 -w '%{http_code}' "http://127.0.0.1:${PORT}/health/" 2>/dev/null || true)"
+STATE="$(docker inspect -f '{{.State.Status}} oom={{.State.OOMKilled}} exit={{.State.ExitCode}}' "${CID}" 2>/dev/null)"
+info "post-bomb container state='${STATE}' /health=${HEALTH:-<none>}"
+
+if echo "${STATE}" | grep -q 'oom=true' || echo "${STATE}" | grep -q 'exit=137'; then
+    fail "process was KERNEL OOM-killed (${STATE}) -- DuckDB stopped honoring the cgroup limit; this is the #71 regression."
+    rc=1
+fi
+if echo "${BODY}" | grep -qiE 'out of memory'; then
+    pass "query failed with a graceful DuckDB 'Out of Memory' error (no kernel kill)"
+else
+    fail "expected a graceful 'Out of Memory' error, got: $(echo "${BODY}" | head -c 200)"; rc=1
+fi
+if [ "${HEALTH}" = "200" ]; then
+    pass "server still serving requests after the bomb (health=200)"
+else
+    fail "server not healthy after the bomb (health=${HEALTH})"; rc=1
+fi
+
+echo
+if [ "${rc}" -eq 0 ]; then
+    pass "resource-limit smoke test PASSED: DuckDB honors the cgroup limit and degrades gracefully."
+else
+    fail "resource-limit smoke test FAILED (see above)."
+fi
+exit "${rc}"


### PR DESCRIPTION
## Summary

Issue #71 proposed an opt-in `--auto-memory` flag on the premise that **DuckDB sizes `max_memory` from host RAM and ignores container cgroup limits**, leading to kernel OOM kills (exit 137).

I validated that premise against the bundled **DuckDB 1.5.2** by running the binary in memory/CPU-limited containers — and it is **obsolete**: DuckDB already honors cgroup limits.

With **no** config and **no** flag:

| Container limit | DuckDB `memory_limit` | DuckDB `threads` |
|---|---|---|
| `--memory=512m` | **409.5 MiB** (≈80% of cgroup) | — |
| `--memory=1g --cpus=2` | **819 MiB** (≈80% of cgroup) | **2** (from CPU quota) |

A ~3 GiB query in a 1 GiB container raises a **graceful** DuckDB `Out of Memory Error` (HTTP 500) and the **server survives** — no kernel kill. (`using 32 threads` is Crow's HTTP pool, not DuckDB parallelism.)

So instead of a redundant override, this ships **observability + a regression guard**:

- **`src/system_resources.{hpp,cpp}`** — cgroup v1/v2 memory + CPU detection with injectable `/sys/fs/cgroup` roots; unit-tested (`test/cpp/system_resources_test.cpp`).
- **Startup log** — `database_manager` emits a `resource-limits:` INFO line reporting the detected ceiling + source (`cgroup-v2`/`cgroup-v1`/`meminfo`/`hardware`). **No DuckDB setting is changed**; `duckdb.max_memory` / `duckdb.threads` still override when set explicitly.
- **`make smoke-test-resources`** (`test/integration/smoke_resource_limits.sh`) — a Docker regression guard asserting graceful degradation (HTTP 500 OOM, server survives) and the cgroup-detection log. Skips off Linux/Docker.
- **Docs** — `DESIGN_DECISIONS §10` records the finding; `CONFIG_REFERENCE` documents the cgroup behavior and how to pin explicit values.

### Why not the `--auto-memory` override?

Its only unique value over DuckDB's built-in behavior would be a tunable percentage (DuckDB hardcodes ~80%), which didn't justify the cross-platform detection/precedence surface area. If the tunable knob is wanted (e.g. target 50% for headroom), it can be a thin follow-up.

## Test plan

- [x] `make test` — all **649** unit tests pass on the release build (incl. 26 new `[system_resources]` assertions covering cgroup v1/v2 memory + CPU parsers and sentinel handling).
- [x] `make smoke-test-resources` — passes on a Linux+Docker host: startup log shows `source=cgroup-v2 available=1024MB`, the 3 GiB bomb returns a graceful OOM, and `/health` stays 200.
- [x] Manual: startup logs report the detected ceiling; explicit `duckdb.max_memory`/`threads` still take effect.

Closes #71
