### PR TITLE
chore: bump bundled DuckDB to v1.5.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,10 @@ jobs:
   # Windows Build (AMD64)
   # -------------------------------------------------------------------------------------------------
   windows-build:
-    runs-on: windows-latest
+    # Pinned to windows-2022: the `-G "Visual Studio 17 2022"` generator below
+    # needs VS 2022, which the migrated `windows-latest` image no longer exposes
+    # ("could not find any instance of Visual Studio"). windows-2022 ships VS 2022.
+    runs-on: windows-2022
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
       VCPKG_ROOT: ${{ github.workspace }}\\vcpkg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - ~13,400 lines of C++ code across 54 files
 - Supports Linux (x86/ARM64), macOS (Intel/Apple Silicon), and Windows
 - Declarative API philosophy: logic lives in YAML/SQL, not compiled code
-- Single binary deployment with built-in DuckDB 1.5.2
+- Single binary deployment with built-in DuckDB 1.5.3
 
 ## Architecture Documentation
 
@@ -679,7 +679,7 @@ make integration-test-ci           # Full suite with server management
 
 ### DuckDB Integration
 
-- Embedded in-process OLAP database (v1.5.2)
+- Embedded in-process OLAP database (v1.5.3)
 - Extensions for external data sources: BigQuery, Postgres, Iceberg, Parquet, CSV
 - Query execution with result caching
 
@@ -1206,7 +1206,7 @@ Common extensions:
 
 | Library | Purpose |
 |---------|---------|
-| **DuckDB 1.5.2** | In-process OLAP database |
+| **DuckDB 1.5.3** | In-process OLAP database |
 | **Crow** | C++ web framework |
 | **OpenSSL** | Encryption/security |
 | **jwt-cpp** | JWT authentication |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Windows-specific settings
 if(WIN32)
-    # Use static runtime libraries for Windows builds (/MT, matching DuckDB 1.5.2)
+    # Use static runtime libraries for Windows builds (/MT, matching DuckDB 1.5.3)
     add_definitions(-D_WIN32_WINNT=0x0601)  # Target Windows 7 or later
 
     # Set vcpkg triplet for Windows
@@ -17,7 +17,7 @@ if(WIN32)
         endif()
     endif()
 
-    # Force static CRT (/MT) to match DuckDB 1.5.2's unconditional
+    # Force static CRT (/MT) to match DuckDB 1.5.3's unconditional
     # set(CMAKE_MSVC_RUNTIME_LIBRARY ...) in duckdb/CMakeLists.txt:39.
     # vcpkg's toolchain only sets /MT for packages; flapi's own targets need
     # this explicit setting or MSVC defaults to /MD → LNK2038 at link time.
@@ -197,7 +197,7 @@ find_package(zstd CONFIG REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
 
 # Add DuckDB
-set(DUCKDB_EXPLICIT_VERSION 1.5.2)
+set(DUCKDB_EXPLICIT_VERSION 1.5.3)
 set(ENABLE_EXTENSION_AUTOLOADING true)
 set(ENABLE_EXTENSION_AUTOINSTALL true)
 if (WIN32)

--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ The easiest way to get started with flAPI is to use the pre-built docker image.
 ```
 
 
-The image is pretty small and mainly contains the flAPI binary which is statically linked against [DuckDB v1.5.2](https://github.com/duckdb/duckdb/releases/tag/v1.5.2). Details about the docker image can be found in the [Dockerfile](./docker/development/Dockerfile).
+The image is pretty small and mainly contains the flAPI binary which is statically linked against [DuckDB v1.5.3](https://github.com/duckdb/duckdb/releases/tag/v1.5.3). Details about the docker image can be found in the [Dockerfile](./docker/development/Dockerfile).
 
 #### 2. Run flAPI:
 Once you have downloaded the binary, you can run flAPI by executing the following command:

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0.0
 **flAPI Version:** >= 1.0.0
-**DuckDB Version:** >= 1.5.2
+**DuckDB Version:** >= 1.5.3
 
 This document provides a complete reference for all configuration options in flAPI, the SQL-to-API framework that generates REST APIs and MCP tools from SQL templates.
 


### PR DESCRIPTION
## Summary

Updates the bundled DuckDB from **v1.5.2 → v1.5.3** — the latest stable bugfix release (published 2026-05-20). Same minor line (1.5.x), bugfix-only delta.

- `duckdb` submodule: `v1.5.2` → `v1.5.3`
- `CMakeLists.txt`: `DUCKDB_EXPLICIT_VERSION 1.5.2 → 1.5.3` (+ matching `/MT` comments)
- Docs: `AGENTS.md` (and its `CLAUDE.md` symlink), `Readme.md`, `docs/CONFIG_REFERENCE.md`

## Test plan

All run locally against a from-scratch release build on Linux x86_64:

- [x] **Build** — clean release build of DuckDB 1.5.3 + flApi.
- [x] **Unit tests** (`make test`) — **642/642 pass**, 0 failed (1 AWS test skipped as usual).
- [x] **Runtime version** — `SELECT version()` returns `v1.5.3`; server boots cleanly (no extension-cache issue).
- [x] **Integration tests** (`make integration-test`) — **507 passed, 25 skipped**. One test (`test_concurrent_schema_refreshes`) errored under parallel `-n auto` with `bind: Address already in use` (port-collision flake) and **passes in isolation** — not a 1.5.3 regression.
- [x] **HTTP-health smoke** (mirrors CI `smoke-test-linux-amd64`) — server healthy, `/api/v1/_config/health` → `status: healthy`.
- [x] **Self-packaging smoke** (mirrors CI `pack-smoke-*`) — `pack` / `info` / `unpack` round-trip OK and reproducible (identical sha256 with fixed `SOURCE_DATE_EPOCH`).

CI will additionally run the full cross-platform build + smoke matrix (Linux amd64/arm64, macOS, Windows).
