### PR TITLE
feat: Derive baked-in version from git tag instead of hardcoding

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,7 @@ jobs:
           -DBUILD_TESTING=OFF `
           -DVCPKG_TARGET_TRIPLET=x64-windows-static `
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
+          ${{ startsWith(github.ref, 'refs/tags/v') && format('-DFLAPI_VERSION_OVERRIDE={0}', github.ref_name) || '' }} `
           ../..
 
     - name: Build
@@ -111,6 +112,7 @@ jobs:
       run: |
         docker run \
           ${{ matrix.arch == 'arm64' && format('-e FLAPI_CROSS_COMPILE="{0}"', matrix.arch) || '' }} \
+          ${{ startsWith(github.ref, 'refs/tags/v') && format('-e CMAKE_EXTRA_FLAGS="-DFLAPI_VERSION_OVERRIDE={0}"', github.ref_name) || '' }} \
           -v `pwd`:/build_dir \
           -v ~/.ccache:/ccache_dir \
           ${BUILD_IMAGE} \
@@ -209,6 +211,8 @@ jobs:
         ./bootstrap-vcpkg.sh -disableMetrics
 
     - name: Build
+      env:
+        CMAKE_EXTRA_FLAGS: ${{ startsWith(github.ref, 'refs/tags/v') && format('-DFLAPI_VERSION_OVERRIDE={0}', github.ref_name) || '' }}
       run: make release-arm64 && make test
 
     - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,30 @@ else()
 endif()
 
 # Set project name and version
-project(flAPI VERSION 0.3.0 LANGUAGES CXX)
+project(flAPI VERSION 26.06.11 LANGUAGES CXX)
+
+# Resolve the version string baked into the binary (FLAPI_VERSION), used for
+# telemetry app_version and `flapi --version`. Priority:
+#   1. -DFLAPI_VERSION_OVERRIDE=...  (set by CI from the git tag)
+#   2. `git describe --tags --dirty` (meaningful versions for local dev builds)
+#   3. "latest"                       (fallback: source tarball / no git)
+# A leading "v" is stripped so the binary reports clean semver (e.g. 0.4.0),
+# matching the wheel pipeline.
+if(FLAPI_VERSION_OVERRIDE)
+    set(FLAPI_VERSION_STR "${FLAPI_VERSION_OVERRIDE}")
+else()
+    execute_process(
+        COMMAND git describe --tags --dirty --always
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE FLAPI_VERSION_STR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if(NOT FLAPI_VERSION_STR)
+        set(FLAPI_VERSION_STR "latest")
+    endif()
+endif()
+string(REGEX REPLACE "^v" "" FLAPI_VERSION_STR "${FLAPI_VERSION_STR}")
+message(STATUS "flAPI version (FLAPI_VERSION): ${FLAPI_VERSION_STR}")
 
 # Basic settings
 set(CMAKE_CXX_STANDARD 17)
@@ -329,7 +352,7 @@ target_link_libraries(flapi-lib PUBLIC
 )
 
 target_compile_definitions(flapi-lib PRIVATE
-    FLAPI_VERSION="${CMAKE_PROJECT_VERSION}"
+    FLAPI_VERSION="${FLAPI_VERSION_STR}"
 )
 
 # Add RPATH settings for macOS
@@ -342,7 +365,7 @@ endif()
 # Create main executable
 add_executable(flapi src/main.cpp)
 target_link_libraries(flapi PRIVATE flapi-lib)
-target_compile_definitions(flapi PRIVATE FLAPI_VERSION="${CMAKE_PROJECT_VERSION}")
+target_compile_definitions(flapi PRIVATE FLAPI_VERSION="${FLAPI_VERSION_STR}")
 set_target_properties(flapi PROPERTIES ENABLE_EXPORTS TRUE)
 
 # macOS reserved-segment for self-packaging (#48). Allocates a

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ ifeq ($(shell uname),Darwin)
 		-DCMAKE_OSX_ARCHITECTURES=x86_64 \
 		-DVCPKG_TARGET_TRIPLET=x64-osx \
 		-DBUILD_TESTING=ON \
-		$(CMAKE_GENERATOR) ../..
+		$(CMAKE_GENERATOR) $(CMAKE_EXTRA_FLAGS) ../..
 	@$(CMAKE) --build $(RELEASE_DIR)-x86_64 --config Release
 
     release-arm64:
@@ -149,7 +149,7 @@ ifeq ($(shell uname),Darwin)
 		-DCMAKE_OSX_ARCHITECTURES=arm64 \
 		-DVCPKG_TARGET_TRIPLET=arm64-osx \
 		-DBUILD_TESTING=ON \
-		$(CMAKE_GENERATOR) ../..
+		$(CMAKE_GENERATOR) $(CMAKE_EXTRA_FLAGS) ../..
 	@$(CMAKE) --build $(RELEASE_DIR)-arm64 --config Release
 
     # Override the default release target on macOS


### PR DESCRIPTION
## Summary
- Telemetry `app_version` (and `flapi --version`) always reported `0.3.0` — the hardcoded `project()` version — while real releases use CalVer tags (e.g. `v26.06.11`). The tag only flowed into the PyPI wheel name, never into the binary.
- CMake now resolves the baked-in `FLAPI_VERSION` from the git tag, with sensible fallbacks; CI injects the tag on release builds.

## Changes
- **CMakeLists.txt**: resolve `FLAPI_VERSION` in priority order — (1) `-DFLAPI_VERSION_OVERRIDE` (CI from tag), (2) `git describe --tags --dirty` (local dev), (3) `"latest"` (source tarball / no git). Leading `v` stripped → clean semver.
- **Makefile**: forward `$(CMAKE_EXTRA_FLAGS)` on the macOS `release-x86_64` / `release-arm64` targets (the generic `release` target already did).
- **build.yaml**: on `v*` tag pushes, inject `-DFLAPI_VERSION_OVERRIDE=${{ github.ref_name }}` across Windows, Linux (via `docker run -e`), and macOS builds.

## Test plan
- [x] Validated all three resolution paths in isolation with `cmake -P` (override → `0.4.0`, no-override → `26.06.11-dirty`, empty override → falls back).
- [ ] CI build passes on all four platforms.
- [ ] After release, confirm PostHog `app_version` matches the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)