### PR TITLE
Restore flapii CLI & VSCode extension parity with server

### DIFF
--- a/cli/shared/package.json
+++ b/cli/shared/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --dts --watch"
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "axios": "^1.7.7",

--- a/cli/shared/src/apiClient.ts
+++ b/cli/shared/src/apiClient.ts
@@ -257,12 +257,14 @@ export class FlapiApiClient {
   }
 
   /**
-   * Test an endpoint with given parameters
+   * Test an endpoint with given parameters.
+   * Targets the server's `/template/test` route (the only test route that exists;
+   * see src/config_service.cpp).
    */
   async testEndpoint(pathOrName: string, parameters: Record<string, any>): Promise<any> {
     const slug = pathToSlug(pathOrName);
     const response = await this.client.post(
-      `/api/v1/_config/endpoints/${slug}/test`,
+      `/api/v1/_config/endpoints/${slug}/template/test`,
       { parameters }
     );
     return response.data;

--- a/cli/src/commands/cache/index.ts
+++ b/cli/src/commands/cache/index.ts
@@ -275,4 +275,51 @@ export function registerCacheCommands(program: Command, ctx: CliContext) {
         process.exitCode = 1;
       }
     });
+
+  cache
+    .command('gc <path>')
+    .description('Run garbage collection on cache snapshots (DuckLake)')
+    .action(async (path: string) => {
+      const spinner = Console.spinner(`Running cache GC for ${path}...`);
+      try {
+        const endpointUrl = buildEndpointUrl(path, 'cache/gc');
+        const response = await ctx.client.post(endpointUrl, {});
+        spinner.succeed(chalk.green(`✓ Cache GC for ${path} completed`));
+
+        if (ctx.config.output !== 'json') {
+          Console.info(chalk.cyan(`\n🧹 Cache GC: ${path}`));
+          Console.info(chalk.gray('═'.repeat(60)));
+        }
+        renderJson(response.data, ctx.config.jsonStyle);
+      } catch (error) {
+        spinner.fail(chalk.red(`✗ Failed to run cache GC for ${path}`));
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+
+  cache
+    .command('audit [path]')
+    .description('Get cache sync audit log (for one endpoint, or all endpoints if no path given)')
+    .action(async (path?: string) => {
+      const target = path ? `for ${path}` : '(all endpoints)';
+      const spinner = Console.spinner(`Fetching cache audit log ${target}...`);
+      try {
+        const url = path
+          ? buildEndpointUrl(path, 'cache/audit')
+          : '/api/v1/_config/cache/audit';
+        const response = await ctx.client.get(url);
+        spinner.succeed(chalk.green(`✓ Cache audit log ${target} retrieved`));
+
+        if (ctx.config.output !== 'json') {
+          Console.info(chalk.cyan(`\n📋 Cache Audit ${target}`));
+          Console.info(chalk.gray('═'.repeat(60)));
+        }
+        renderJson(response.data, ctx.config.jsonStyle);
+      } catch (error) {
+        spinner.fail(chalk.red(`✗ Failed to fetch cache audit log ${target}`));
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
 }

--- a/cli/src/commands/config/index.ts
+++ b/cli/src/commands/config/index.ts
@@ -3,10 +3,12 @@ import type { CliContext } from '../../lib/types';
 import { registerConfigCommand } from './show';
 import { registerValidateCommand } from './validate';
 import { registerLogLevelCommands } from './log-level';
+import { registerInfoCommands } from './info';
 
 export function registerConfigCommands(program: Command, ctx: CliContext) {
   const configCmd = registerConfigCommand(program, ctx);
   registerValidateCommand(configCmd, ctx);
   registerLogLevelCommands(configCmd, ctx);
+  registerInfoCommands(configCmd, ctx);
 }
 

--- a/cli/src/commands/config/info.ts
+++ b/cli/src/commands/config/info.ts
@@ -1,0 +1,76 @@
+import type { Command } from 'commander';
+import type { CliContext } from '../../lib/types';
+import { Console } from '../../lib/console';
+import { handleError } from '../../lib/errors';
+import { renderJson } from '../../lib/render';
+import chalk from 'chalk';
+
+export function registerInfoCommands(config: Command, ctx: CliContext) {
+  config
+    .command('env')
+    .description('List whitelisted environment variables and their availability')
+    .action(async () => {
+      let spinner;
+      if (ctx.config.output !== 'json') {
+        spinner = Console.spinner('Fetching environment variables...');
+      }
+      try {
+        const response = await ctx.client.get('/api/v1/_config/environment-variables');
+        if (spinner) {
+          spinner.succeed(chalk.green('✓ Environment variables retrieved'));
+        }
+        const data = response.data;
+
+        if (ctx.config.output === 'json') {
+          renderJson(data, ctx.config.jsonStyle);
+        } else {
+          Console.info(chalk.cyan('\n🔐 Environment Variables'));
+          Console.info(chalk.gray('═'.repeat(60)));
+          const vars = Array.isArray(data?.variables) ? data.variables : [];
+          if (vars.length === 0) {
+            Console.info(chalk.gray('No environment variables configured'));
+          } else {
+            vars.forEach((v: any) => {
+              const status = v.available ? chalk.green('available') : chalk.yellow('not set');
+              Console.info(chalk.bold.blue(v.name) + ' ' + status);
+            });
+          }
+        }
+      } catch (error) {
+        if (spinner) {
+          spinner.fail(chalk.red('✗ Failed to fetch environment variables'));
+        }
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+
+  config
+    .command('filesystem')
+    .description('Show the project filesystem structure')
+    .action(async () => {
+      let spinner;
+      if (ctx.config.output !== 'json') {
+        spinner = Console.spinner('Fetching filesystem structure...');
+      }
+      try {
+        const response = await ctx.client.get('/api/v1/_config/filesystem');
+        if (spinner) {
+          spinner.succeed(chalk.green('✓ Filesystem structure retrieved'));
+        }
+        const data = response.data;
+
+        if (ctx.config.output !== 'json') {
+          Console.info(chalk.cyan('\n📁 Project Filesystem'));
+          Console.info(chalk.gray('═'.repeat(60)));
+        }
+        renderJson(data, ctx.config.jsonStyle);
+      } catch (error) {
+        if (spinner) {
+          spinner.fail(chalk.red('✗ Failed to fetch filesystem structure'));
+        }
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/cli/src/commands/endpoints/index.ts
+++ b/cli/src/commands/endpoints/index.ts
@@ -63,6 +63,43 @@ export function registerEndpointCommands(program: Command, ctx: CliContext) {
       }
     });
 
+  endpoints
+    .command('parameters <path>')
+    .description('Get parameter definitions for an endpoint')
+    .option('--output <format>', 'Output format: json or table')
+    .action(async (path: string, options: { output?: 'json' | 'table' }) => {
+      const spinner = Console.spinner(`Fetching parameters for ${path}...`);
+      try {
+        const endpointUrl = buildEndpointUrl(path, 'parameters');
+        const response = await ctx.client.get(endpointUrl);
+        spinner.succeed(chalk.green(`✓ Parameters for ${path} retrieved`));
+        const data = response.data;
+        const resolved = applyOutputOverride(ctx.config, options.output);
+        if (resolved.output === 'json') {
+          renderJson(data, resolved.jsonStyle);
+        } else {
+          Console.info(chalk.cyan(`\n🔧 Parameters: ${path}`));
+          Console.info(chalk.gray('═'.repeat(60)));
+          const params = Array.isArray(data?.parameters) ? data.parameters : [];
+          if (params.length === 0) {
+            Console.info(chalk.gray('No parameters defined'));
+          } else {
+            params.forEach((p: any) => {
+              const req = p.required ? chalk.red('required') : chalk.gray('optional');
+              Console.info(chalk.bold.blue(p.name) + chalk.gray(` (in: ${p.in})`) + ' ' + req);
+              if (p.description) {
+                Console.info(chalk.gray(`  ${p.description}`));
+              }
+            });
+          }
+        }
+      } catch (error) {
+        spinner.fail(chalk.red(`✗ Failed to fetch parameters for ${path}`));
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+
   withPayloadOptions(
     endpoints
       .command('create')

--- a/cli/src/commands/health.ts
+++ b/cli/src/commands/health.ts
@@ -1,0 +1,44 @@
+import type { Command } from 'commander';
+import type { CliContext } from '../lib/types';
+import { Console } from '../lib/console';
+import { handleError } from '../lib/errors';
+import { renderJson } from '../lib/render';
+import chalk from 'chalk';
+
+export function registerHealthCommand(program: Command, ctx: CliContext) {
+  program
+    .command('health')
+    .description('Get server health (database, endpoints, Arrow IPC, VFS, credential status)')
+    .action(async () => {
+      let spinner;
+      if (ctx.config.output !== 'json') {
+        spinner = Console.spinner('Fetching server health...');
+      }
+      try {
+        const response = await ctx.client.get('/api/v1/_config/health');
+        if (spinner) {
+          spinner.succeed(chalk.green('✓ Server health retrieved'));
+        }
+        const data = response.data;
+
+        if (ctx.config.output === 'json') {
+          renderJson(data, ctx.config.jsonStyle);
+        } else {
+          Console.info(chalk.cyan('\n❤️  Server Health'));
+          Console.info(chalk.gray('═'.repeat(60)));
+          const status = data?.status ?? 'unknown';
+          const healthy = ['ok', 'healthy', 'up'].includes(String(status).toLowerCase());
+          Console.info(
+            chalk.bold.blue('Status: ') + (healthy ? chalk.green(status) : chalk.yellow(status)),
+          );
+          renderJson(data, ctx.config.jsonStyle);
+        }
+      } catch (error) {
+        if (spinner) {
+          spinner.fail(chalk.red('✗ Failed to fetch server health'));
+        }
+        handleError(error, ctx.config);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig } from './lib/config';
 import { createApiClient } from './lib/http';
 import { handleError } from './lib/errors';
 import { registerPingCommand } from './commands/ping';
+import { registerHealthCommand } from './commands/health';
 import { registerConfigCommands } from './commands/config';
 import { registerProjectCommands } from './commands/project';
 import { registerEndpointCommands } from './commands/endpoints';
@@ -55,6 +56,7 @@ export async function createCli(argv = process.argv) {
   };
 
   registerPingCommand(program, ctx);
+  registerHealthCommand(program, ctx);
   registerConfigCommands(program, ctx);
   registerProjectCommands(program, ctx);
   registerEndpointCommands(program, ctx);

--- a/cli/vscode-extension/package.json
+++ b/cli/vscode-extension/package.json
@@ -367,6 +367,8 @@
     }
   },
   "scripts": {
+    "build:shared": "npm --prefix ../shared run build",
+    "prebuild": "npm run build:shared",
     "build": "webpack --mode production && npm run build:webview",
     "dev": "webpack --mode development --watch",
     "build:webview": "webpack --config webview/webpack.config.js --mode production",

--- a/cli/vscode-extension/src/webview/endpointTesterPanel.ts
+++ b/cli/vscode-extension/src/webview/endpointTesterPanel.ts
@@ -1942,27 +1942,27 @@ export class EndpointTesterPanel {
           let summaryHTML = '<div style="font-weight: bold; margin-bottom: 8px; color: var(--vscode-activityBarBadge-background);">📝 Write Operation Result</div>';
           
           if (parsedData.rows_affected !== undefined) {
-            summaryHTML += `<div style="margin: 4px 0;"><strong>Rows Affected:</strong> <span style="color: var(--vscode-textLink-foreground);">${parsedData.rows_affected}</span></div>`;
+            summaryHTML += \`<div style="margin: 4px 0;"><strong>Rows Affected:</strong> <span style="color: var(--vscode-textLink-foreground);">\${parsedData.rows_affected}</span></div>\`;
           }
-          
+
           if (parsedData.last_insert_id !== undefined) {
-            summaryHTML += `<div style="margin: 4px 0;"><strong>Last Insert ID:</strong> <span style="color: var(--vscode-textLink-foreground);">${parsedData.last_insert_id}</span></div>`;
+            summaryHTML += \`<div style="margin: 4px 0;"><strong>Last Insert ID:</strong> <span style="color: var(--vscode-textLink-foreground);">\${parsedData.last_insert_id}</span></div>\`;
           }
-          
+
           if (parsedData.returned_data && Array.isArray(parsedData.returned_data) && parsedData.returned_data.length > 0) {
-            summaryHTML += `<div style="margin: 4px 0;"><strong>Returned Data:</strong> ${parsedData.returned_data.length} record(s)</div>`;
+            summaryHTML += \`<div style="margin: 4px 0;"><strong>Returned Data:</strong> \${parsedData.returned_data.length} record(s)</div>\`;
           }
-          
+
           if (parsedData.errors && Array.isArray(parsedData.errors) && parsedData.errors.length > 0) {
-            summaryHTML += `<div style="margin: 8px 0; padding: 8px; background: var(--vscode-inputValidation-errorBackground); border-radius: 4px;">`;
+            summaryHTML += \`<div style="margin: 8px 0; padding: 8px; background: var(--vscode-inputValidation-errorBackground); border-radius: 4px;">\`;
             summaryHTML += '<div style="font-weight: bold; color: var(--vscode-errorForeground); margin-bottom: 4px;">⚠️ Validation Errors:</div>';
             parsedData.errors.forEach(error => {
-              summaryHTML += `<div style="margin: 2px 0; color: var(--vscode-errorForeground);">• ${error.field || 'Unknown'}: ${error.message || 'Error'}</div>`;
+              summaryHTML += \`<div style="margin: 2px 0; color: var(--vscode-errorForeground);">• \${error.field || 'Unknown'}: \${error.message || 'Error'}</div>\`;
             });
             summaryHTML += '</div>';
           } else if (parsedData.error) {
-            summaryHTML += `<div style="margin: 8px 0; padding: 8px; background: var(--vscode-inputValidation-errorBackground); border-radius: 4px;">`;
-            summaryHTML += `<div style="color: var(--vscode-errorForeground);">⚠️ Error: ${parsedData.error.field || 'Unknown'}: ${parsedData.error.message || 'Error'}</div>`;
+            summaryHTML += \`<div style="margin: 8px 0; padding: 8px; background: var(--vscode-inputValidation-errorBackground); border-radius: 4px;">\`;
+            summaryHTML += \`<div style="color: var(--vscode-errorForeground);">⚠️ Error: \${parsedData.error.field || 'Unknown'}: \${parsedData.error.message || 'Error'}</div>\`;
             summaryHTML += '</div>';
           }
           

--- a/docs/CLIENT_PARITY_AUDIT.md
+++ b/docs/CLIENT_PARITY_AUDIT.md
@@ -1,0 +1,192 @@
+# Client Parity Audit — flapii CLI & VSCode Extension vs. flapi Server
+
+**Date:** 2026-06-14
+**Server reference:** tag `v26.06.13` (binary tested: `build/release/flapi`, built 2026-06-11, self-reported version `1.0`)
+**flapii CLI:** `cli/` — version `0.1.0`
+**VSCode extension:** `cli/vscode-extension/` — version `0.1.0`
+**Shared package:** `cli/shared/` (`@flapi/shared`) — version `0.1.0`
+
+Scope: **audit + verify only** — no feature changes were made. The clients were
+built and exercised against a live server; results below are backed by either a
+live request or a source citation.
+
+---
+
+## TL;DR
+
+| Client | Builds? | Tests | Live behaviour | On par with server? |
+|--------|---------|-------|----------------|---------------------|
+| **flapii CLI** | ✅ yes (tsup) | ✅ 41/41 unit pass; ⚠️ integration blocked by server-binary crash (not a CLI bug) | ✅ all exercised commands work against live server | **Mostly** — works, but missing ~6 commands the server now supports |
+| **VSCode extension** | ❌ **NO** — webpack build fails | ❌ no test suite exists | ⛔ cannot be packaged/run | **No** — broken in-repo since 2025-11-02 |
+
+**Headline:** The CLI is healthy and largely keeps up with the server, with a
+handful of missing commands. The **VSCode extension does not compile** and has not
+compiled since its last commit (`fcebf3a`, "First draft of write support",
+2025-11-02) — it is effectively unshippable today.
+
+---
+
+## 1. Build / Run status (evidence)
+
+### Server
+- `build/release/flapi` boots with `--config-service` and serves the full ConfigService
+  API (verified by live HTTP probes below).
+- **Caveat 1 (environment):** the bundled `examples/data/cache.ducklake` is a stale
+  DuckLake catalog (version 0.3 vs extension 1.0) and aborts startup
+  (`DuckLake catalog version mismatch`). Worked around by moving it aside (restorable
+  backup in `/tmp/flapi-ducklake-bak/`).
+- **Caveat 2 (instability):** under the CLI integration harness the server binary
+  crashes on startup with **varying signals** (SIGSEGV / SIGABRT / SIGBUS). The same
+  binary runs fine when launched manually with the same config, so this looks like
+  binary/environment staleness — the working tree has a **modified `duckdb` submodule**
+  (`git status: M duckdb`) that the 2026-06-11 prebuilt binary predates. Not a client defect.
+
+### flapii CLI
+- `npm ci` ✅, `npm run build` (tsup) ✅ — `ESM build success`.
+- `npm test` (Vitest, nock-mocked): **41/41 pass** (8 files). *(One spurious failure only
+  appears if `FLAPI_BASE_URL` is exported into the test env — a test-isolation quirk in
+  `test/unit/config.spec.ts`, not a product bug.)*
+- `npm run test:integration`: **blocked** — `test/integration/setup.ts` spawns the real
+  `build/release/flapi`, which crashes (see Caveat 2). 19 tests skipped, 0 ran. The harness
+  itself is correct; it is gated on a working server binary.
+- **Live manual smoke test** against a manually-launched server (`:8099`, `--config-service`):
+  `ping`, `endpoints list`, `endpoints get`, `templates get`, `templates expand`,
+  `cache get`, `schema connections`, `config log-level get`, `mcp tools list` — **all exit 0
+  and return correct data.**
+
+### VSCode extension
+- `npm ci` ✅.
+- `npm run build` (webpack ext + webview): ❌ **FAILS, exit 1.**
+- `npx tsc --noEmit`: ❌ fails (same errors).
+- Two error classes, both in **committed** code (no local modifications), both from commit
+  `fcebf3a` (2025-11-02):
+  1. `src/providers/endpointsProvider.ts:60,61,79,80` —
+     `TS2339: Property 'operation' does not exist on type 'EndpointConfig'` (type drift: the
+     provider reads `endpoint.operation`, which the `EndpointConfig` type no longer declares).
+  2. `src/webview/endpointTesterPanel.ts:1895–2030` — cascade of `TS1005 / TS1110 / TS1127`
+     ("`;` expected", "Type expected", "Invalid character"). A malformed/un-terminated
+     template literal in the "write operation result" block desyncs the parser. This is the
+     half-finished "write support" draft.
+
+---
+
+## 2. Parity matrix (server capability → client coverage)
+
+Legend: ✅ exposed · ⚠️ partial / indirect · ❌ not exposed
+The extension column reflects **source intent**; remember the extension **does not build**, so
+every ✅ there is currently non-functional.
+
+| Server capability (ConfigService / MCP) | Server route | flapii CLI | VSCode ext |
+|---|---|---|---|
+| Project config (get) | `GET /_config/project` | ✅ `project get` / `ping` | ✅ openProject |
+| Project config (update) | `PUT /_config/project` | ❌ | ❌ — *(server returns 501; not implemented)* |
+| Environment variables | `GET /_config/environment-variables` | ❌ | ⚠️ client method exists; UI ("Variables") removed |
+| Endpoints — list | `GET /_config/endpoints` | ✅ `endpoints list` | ✅ explorer |
+| Endpoints — get | `GET /_config/endpoints/{slug}` | ✅ `endpoints get` | ✅ |
+| Endpoints — create/update/delete | `POST/PUT/DELETE …/{slug}` | ✅ `endpoints create/update/delete` | ⚠️ create only (`newEndpoint`) |
+| Endpoints — validate | `POST …/{slug}/validate` | ✅ `endpoints validate` | ✅ validateYaml |
+| Endpoints — reload | `POST …/{slug}/reload` | ✅ `endpoints reload` | ✅ reloadEndpoint |
+| Endpoints — parameters | `GET …/{slug}/parameters` | ❌ | ✅ openParameters |
+| Endpoints — by-template | `POST …/by-template` | ❌ | ✅ (used by SQL tester) |
+| Template — get/update | `GET/PUT …/{slug}/template` | ✅ `templates get/update` | ✅ |
+| Template — expand | `POST …/{slug}/template/expand` | ✅ `templates expand` | ✅ expandTemplate |
+| Template — test (exec) | `POST …/{slug}/template/test` | ✅ `templates test` | ✅ testTemplate |
+| Cache — get/update | `GET/PUT …/{slug}/cache` | ✅ `cache get/update` | ✅ openCache |
+| Cache — template get/update | `GET/PUT …/{slug}/cache/template` | ✅ `cache template / update-template` | ⚠️ |
+| Cache — refresh | `POST …/{slug}/cache/refresh` | ✅ `cache refresh` | ❌ |
+| **Cache — GC** | `POST …/{slug}/cache/gc` | ❌ | ❌ |
+| **Cache — audit (per-endpoint)** | `GET …/{slug}/cache/audit` | ❌ | ❌ |
+| **Cache — audit (global)** | `GET /_config/cache/audit` | ❌ | ❌ |
+| Schema — get | `GET /_config/schema` | ✅ `schema get/connections/tables` | ✅ schema browser |
+| Schema — refresh | `POST /_config/schema/refresh` | ✅ `schema refresh` | ✅ schema.refresh |
+| Log level — get/set | `GET/PUT /_config/log-level` | ✅ `config log-level get/set/list` | ❌ |
+| **Filesystem tree** | `GET /_config/filesystem` | ❌ | ⚠️ client method exists |
+| **Health / metrics** | `GET /_config/health` | ❌ (`ping` hits `/project`) | ❌ |
+| OpenAPI doc | `GET /doc.yaml` | ❌ | ❌ |
+| MCP tools/resources/prompts (user-defined) | `GET /_config/endpoints` (MCP slugs) | ✅ `mcp tools/resources/prompts list/get` | ✅ openMcpItem |
+| MCP JSON-RPC protocol (`/mcp/jsonrpc`, `/mcp/health`) | — | ❌ (no MCP client/exec) | ❌ |
+| 20 `flapi_*` MCP config tools (`--config-service`) | via `/mcp/jsonrpc` | ➖ N/A (consumed by MCP clients, not the CLI) | ➖ N/A |
+| Self-packaging (`pack`/`info`/`unpack`) | server-binary subcommands | ➖ N/A (server binary, not flapii) | ➖ N/A |
+
+All "❌ on server route" cells were confirmed live: the route returns **200** while the CLI
+reports `error: unknown command` (verified for `cache gc`, `cache audit`, `environment-variables`,
+`filesystem`, `health`).
+
+---
+
+## 3. Findings, prioritized
+
+### P0 — Broken / unshippable
+1. **VSCode extension does not compile.** Webpack + `tsc` both fail. Two root causes
+   (`endpointsProvider.ts` type drift on `operation`; `endpointTesterPanel.ts` malformed
+   template literal in the write-support draft). Broken in-repo since 2025-11-02. The extension
+   cannot be packaged or run until fixed. *(Files: `cli/vscode-extension/src/providers/endpointsProvider.ts:60-80`,
+   `cli/vscode-extension/src/webview/endpointTesterPanel.ts:1895-2030`.)*
+
+### P1 — Functional parity gaps (server has it; clients don't)
+2. **CLI missing commands** for live server capabilities: `cache gc`, `cache audit`
+   (per-endpoint + global), `endpoints parameters`, `environment-variables`, `filesystem`,
+   and a real `health` command (today `ping` queries `/project`, not `/health`, so it never
+   surfaces DB / Arrow-IPC / VFS / credential status).
+3. **Dead/broken client method:** `FlapiApiClient.testEndpoint()`
+   (`cli/shared/src/apiClient.ts:262`) POSTs to `/_config/endpoints/{slug}/test`, which **does
+   not exist** on the server (only `/template/test` does, `config_service.cpp:393`). Any caller
+   would get a 404. The CLI's `templates test` correctly targets `template/test`, so the method
+   is currently unused — but it is a latent landmine.
+
+### P2 — Architectural drift (violates CLAUDE.md "share a common API client")
+4. **Two divergent `FlapiApiClient` implementations.** `cli/shared/src/apiClient.ts` (axios,
+   full surface, used by the CLI) vs. `cli/vscode-extension/src/shared/apiClient.ts` (separate
+   impl, validate/reload/template subset). The mandated single shared client does not exist in
+   practice; the extension does not consume `@flapi/shared`'s client.
+5. **Dead code in the extension:** the "Variables provider" was removed but its refresh call /
+   wiring remains (`extension.ts` ~898-908); unused `include_variables` fetch.
+6. **Stubbed TODOs in the extension:** single-YAML backend parse
+   (`codelens/endpointTestProvider.ts:186`), multi-endpoint selector
+   (`webview/sqlTemplateTesterPanel.ts:118`).
+
+### P3 — Hygiene / staleness
+7. **No test suite for the extension** (no framework, no specs) — the broken build would have
+   been caught by even a smoke compile in CI.
+8. **Version skew:** server `v26.06.13`; all three JS packages pinned at `0.1.0`. Extension
+   untouched ~7 months; CLI's last feature work 2026-01-16.
+9. **Examples ship a stale DuckLake catalog** that aborts a fresh server boot (env, but
+   user-facing for anyone running `examples/`).
+
+---
+
+## 4. Verdict & minimum work to reach parity
+
+**flapii CLI — "on par": mostly yes.** It builds, its unit tests pass, and every exercised
+command works against a live server. To call it fully on par, add the six missing commands in
+P1 #2 (the shared client already has methods for `parameters`, `environment-variables`,
+`filesystem`), fix the `testEndpoint()` route in #3, and wire a real `health` command.
+
+**VSCode extension — "on par": no.** It is broken at the build level and cannot run. Minimum to
+restore: fix the two compile errors (P0 #1), then re-assess parity — on paper its feature set
+is actually *wider* than the CLI's (parameters, by-template, interactive testers), but none of
+it ships until it compiles. Strongly recommend adding a CI compile/typecheck gate (P3 #7) and
+collapsing onto the single shared API client (P2 #4).
+
+---
+
+## 5. Resolution
+
+The P0/P1 findings were filed and fixed in a single PR:
+
+- **#75** (P0) — VSCode extension now builds: escaped the nested template literals in
+  `endpointTesterPanel.ts`, and made `@flapi/shared` build automatically (`prepare` on shared,
+  `prebuild` on the extension) so its types can't go stale. `npm run build` + `tsc --noEmit` both pass.
+- **#76** (P1) — added the missing CLI commands: `health`, `config env`, `config filesystem`,
+  `endpoints parameters <path>`, `cache audit [path]`, `cache gc <path>`. All verified against a
+  live server.
+- **#77** (P1) — `FlapiApiClient.testEndpoint()` now targets the real `…/template/test` route.
+
+P2/P3 items (single shared API client, extension test suite + CI compile gate, version alignment,
+stale example DuckLake catalog) remain open follow-ups, intentionally out of this PR's scope.
+
+## Reproduction notes
+- Server (manual): `./build/release/flapi -c examples/flapi.yaml --port 8099 --config-service --config-service-token testtoken123`
+  (after moving `examples/data/cache.ducklake*` aside).
+- CLI: `cd cli && npm ci && npm run build && npm test`; live: `FLAPI_BASE_URL=… FLAPI_CONFIG_SERVICE_TOKEN=… node dist/index.js <cmd>`.
+- Extension: `cd cli/vscode-extension && npm ci && npm run build` (fails) / `npx tsc --noEmit` (fails).


### PR DESCRIPTION
## Summary
Audit of the `flapii` CLI and VSCode extension against the server's ConfigService surface found one P0 breakage and several P1 gaps. This PR files and fixes them. Full findings in `docs/CLIENT_PARITY_AUDIT.md`.

- **VSCode extension now builds** (Closes #75). It had not compiled since `fcebf3a` (2025-11-02): a malformed template literal in `endpointTesterPanel.ts` desynced the webview HTML literal, and `@flapi/shared` was never built so `EndpointConfig.operation` failed to resolve. Fixed by escaping the nested literals and building shared automatically (`prepare` on shared + `prebuild` on the extension).
- **CLI gains commands for server capabilities it didn't expose** (Closes #76): `health`, `config env`, `config filesystem`, `endpoints parameters <path>`, `cache audit [path]`, `cache gc <path>`.
- **`FlapiApiClient.testEndpoint()` route fixed** (Closes #77): now targets `…/template/test` (the route that exists) instead of `…/test` (404).

## Test plan
- [x] `cd cli/shared && npm run build` ✅
- [x] `cd cli && npm run build && npm test` → 41/41 unit tests pass ✅
- [x] `cd cli/vscode-extension && npm run build` ✅ (exit 0) and `npx tsc --noEmit` → 0 errors ✅
- [x] Live smoke test against `flapi --config-service`: all six new CLI commands work; `testEndpoint` route returns 200 (old `/test` returns 404). `cache audit/gc` on a non-cached endpoint correctly surface the server's 400 "Cache not enabled".

## Out of scope (follow-ups noted in the audit)
Single shared API client unification, an extension test suite + CI compile gate, version alignment (clients pinned `0.1.0` vs server `v26.06.13`), and the stale example DuckLake catalog.