### PR TITLE
fix: Wheel license metadata (Apache-2.0 → BUSL-1.1) + MCP registry marker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -888,7 +888,7 @@ jobs:
           --binary ./artifacts/flapii-linux-amd64/flapii --entry-point flapii \
           --platform linux-x86_64 --output-dir dist/flapi-io \
           --description "SQL-to-API server" --author "DataZoo GmbH" \
-          --license Apache-2.0 --url https://github.com/DataZooDE/flapi \
+          --license BUSL-1.1 --url https://github.com/DataZooDE/flapi \
           --readme ./Readme.md
 
         bin-to-wheel --name flapi-io --version "$WHEEL_VERSION" \
@@ -896,7 +896,7 @@ jobs:
           --binary ./artifacts/flapii-linux-arm64/flapii --entry-point flapii \
           --platform linux-arm64 --output-dir dist/flapi-io \
           --description "SQL-to-API server" --author "DataZoo GmbH" \
-          --license Apache-2.0 --url https://github.com/DataZooDE/flapi \
+          --license BUSL-1.1 --url https://github.com/DataZooDE/flapi \
           --readme ./Readme.md
 
         bin-to-wheel --name flapi-io --version "$WHEEL_VERSION" \
@@ -904,7 +904,7 @@ jobs:
           --binary ./artifacts/flapii-macos-arm64/flapii --entry-point flapii \
           --platform macos-arm64 --output-dir dist/flapi-io \
           --description "SQL-to-API server" --author "DataZoo GmbH" \
-          --license Apache-2.0 --url https://github.com/DataZooDE/flapi \
+          --license BUSL-1.1 --url https://github.com/DataZooDE/flapi \
           --readme ./Readme.md
 
         bin-to-wheel --name flapi-io --version "$WHEEL_VERSION" \
@@ -912,7 +912,7 @@ jobs:
           --binary ./artifacts/flapii-windows-amd64/flapii.exe --entry-point flapii \
           --platform windows-x64 --output-dir dist/flapi-io \
           --description "SQL-to-API server" --author "DataZoo GmbH" \
-          --license Apache-2.0 --url https://github.com/DataZooDE/flapi \
+          --license BUSL-1.1 --url https://github.com/DataZooDE/flapi \
           --readme ./Readme.md
 
     - name: Upload flapi-io wheels

--- a/Readme.md
+++ b/Readme.md
@@ -760,6 +760,12 @@ For more detailed information, check out our [full documentation](docs/):
 - **[Cloud Storage Guide](docs/CLOUD_STORAGE_GUIDE.md)** - Using cloud storage backends (S3, GCS, Azure)
 - **[Architecture & Design](docs/spec/)** - System architecture, design decisions, and component documentation
 
+### MCP Registry
+
+flAPI is listed in the official [MCP Registry](https://registry.modelcontextprotocol.io) under the name below (this line also serves as the registry's PyPI ownership marker):
+
+mcp-name: io.github.datazoode/flapi
+
 ## 📊 Telemetry
 
 flAPI sends anonymous `application_start` and `application_stop` events to help the team understand adoption. No query data, credentials, or personal information is ever sent.


### PR DESCRIPTION
## Summary
- The flapi-io wheel builds passed `--license Apache-2.0` to bin-to-wheel while the repo LICENSE is **BSL 1.1** — PyPI publicly showed the wrong license. Now `--license BUSL-1.1` (SPDX id) in all four platform builds.
- Adds the `mcp-name: io.github.datazoode/flapi` marker to Readme.md (the wheel's PyPI long description). The official MCP Registry requires this marker on the PyPI page to validate package ownership before `mcp-publisher publish` will accept the `server.json` added in #98.

## Test plan
- [ ] After merge, cut a patch release and verify https://pypi.org/p/flapi-io shows BUSL-1.1 and the readme contains the marker

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/flapi/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555571&installation_id=142929061&pr_number=99&repository=DataZooDE%2Fflapi&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fflapi%2Fpull%2F99&signature=6260c70d67ad02ba1b11a6f23b2b97fd0c180c46a344fc60894754d304ec67b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->