### PR TITLE
fix: MCP initialize logging capability must be an object, not null

### DIFF
--- a/src/mcp_route_handlers.cpp
+++ b/src/mcp_route_handlers.cpp
@@ -759,7 +759,7 @@ MCPResponse MCPRouteHandlers::handleInitializeRequest(const MCPRequest& request,
         result["capabilities"]["resources"]["listChanged"] = true;
         result["capabilities"]["prompts"] = crow::json::wvalue();
         result["capabilities"]["prompts"]["listChanged"] = true;
-        result["capabilities"]["logging"] = crow::json::wvalue();  // NEW in 2025-11-25
+        result["capabilities"]["logging"] = crow::json::wvalue::object();  // NEW in 2025-11-25; must serialize as {} — null fails strict client schema validation (#100)
         result["serverInfo"]["name"] = server_info_.name;
         result["serverInfo"]["version"] = server_info_.version;
 


### PR DESCRIPTION
## Summary
- `handleInitialize` emitted `"logging": null` (default-constructed `crow::json::wvalue`); MCP capabilities must be objects, and strict clients (Claude Code) reject the handshake entirely — flAPI was unusable from Claude Code over HTTP.
- One-line fix: `crow::json::wvalue::object()`.

## Test plan
- [x] Reproduced against v26.07.13: `claude mcp add --transport http flapi ...` → ✘ Failed to connect with Zod error at `capabilities.logging`
- [x] Local build: Claude Code connects and calls tools (used to record the agent demo GIF)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/flapi/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786557378&installation_id=142929061&pr_number=102&repository=DataZooDE%2Fflapi&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fflapi%2Fpull%2F102&signature=cf122c1fcabe410b51aecf7cbe5d65fb6bdf5af4dbc6d356276544fcded5f08c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->