### PR TITLE
fix: read_parquet on embed:// bundle entries (GetLastModifiedTime)

### DIFF
--- a/src/duckdb_embed_fs.cpp
+++ b/src/duckdb_embed_fs.cpp
@@ -165,6 +165,13 @@ int64_t EmbeddedFileSystem::GetFileSize(::duckdb::FileHandle& handle) {
     return static_cast<int64_t>(h.data()->size());
 }
 
+::duckdb::timestamp_t EmbeddedFileSystem::GetLastModifiedTime(::duckdb::FileHandle& /*handle*/) {
+    // Bundle entries are immutable in-memory bytes. Report the epoch so
+    // readers that key caches on mtime (e.g. parquet) get a stable value;
+    // anything else would break `SOURCE_DATE_EPOCH` reproducibility.
+    return ::duckdb::timestamp_t(0);
+}
+
 void EmbeddedFileSystem::Seek(::duckdb::FileHandle& handle, ::duckdb::idx_t location) {
     auto& h = AsEmbedded(handle);
     if (h.data() == nullptr) {

--- a/src/include/duckdb_embed_fs.hpp
+++ b/src/include/duckdb_embed_fs.hpp
@@ -39,6 +39,7 @@ public:
               ::duckdb::idx_t location) override;
 
     int64_t GetFileSize(::duckdb::FileHandle& handle) override;
+    ::duckdb::timestamp_t GetLastModifiedTime(::duckdb::FileHandle& handle) override;
 
     void Seek(::duckdb::FileHandle& handle, ::duckdb::idx_t location) override;
     ::duckdb::idx_t SeekPosition(::duckdb::FileHandle& handle) override;


### PR DESCRIPTION
## Summary
- `read_parquet('embed://data/x.parquet')` on a packed binary failed with `Not implemented Error: embed: GetLastModifiedTime is not implemented!` — the parquet reader calls a FileSystem virtual that `EmbeddedFileSystem` didn't override (read_csv doesn't, which is why the documented case worked).
- Override returns epoch: entries are immutable in-memory bytes, and a stable mtime keeps `SOURCE_DATE_EPOCH` reproducibility intact.

## Test plan
- [x] Repro on v26.07.13: pack a tree with a parquet connection → 500 on query
- [ ] CI + local verification with rebuilt binary

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/flapi/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786557414&installation_id=142929061&pr_number=103&repository=DataZooDE%2Fflapi&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fflapi%2Fpull%2F103&signature=1699a544a7415e85925936b3838fc80a3e1866d155237910447414db0fa89c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->