### PR TITLE
feat: add feedback banner and a report_issue link on error payloads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/posthog-telemetry"]
 	path = third_party/posthog-telemetry
 	url = git@github.com:DataZooDE/posthog-telemetry.git
+[submodule "third_party/datazoo-banner"]
+	path = third_party/datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,16 @@ set(DUCKDB_SRC_INCLUDE "${CMAKE_SOURCE_DIR}/duckdb/src/include")
 set(DUCKDB_THIRD_PARTY "${CMAKE_SOURCE_DIR}/duckdb/third_party")
 add_subdirectory(third_party/posthog-telemetry)
 
+# Feedback banner (header-only). Telemetry ON so a printed banner counts as a
+# banner_shown event through the instance configured above; the include dir is
+# carried explicitly because posthog_telemetry is linked without exporting its
+# headers to every consumer here.
+set(DATAZOO_BANNER_TELEMETRY ON CACHE BOOL "" FORCE)
+set(DATAZOO_BANNER_TELEMETRY_INCLUDE_DIR
+    ${CMAKE_SOURCE_DIR}/third_party/posthog-telemetry/include CACHE PATH "" FORCE)
+add_subdirectory(third_party/datazoo-banner)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/datazoo-banner/include)
+
 # Include directories
 find_path(JWT_CPP_INCLUDE_DIRS "jwt-cpp/base.h")
 include_directories(

--- a/Readme.md
+++ b/Readme.md
@@ -821,3 +821,18 @@ See the [LICENSE](./LICENSE) file for the full text.
 If you have any questions or need help, please [open an issue](https://github.com/yourusername/flapi/issues) or join our [community chat](link-to-your-chat).
 
 ---
+
+## Feedback
+
+If flAPI misbehaves — an endpoint that will not serve, a cache that will not invalidate,
+an auth flow that will not complete — please
+[open an issue](https://github.com/DataZooDE/flapi/issues). Deployments differ in ways we
+cannot reproduce here, so a report with your config is the fastest path to a fix. Every
+JSON error response carries a `report_issue` link for exactly this reason.
+
+If it saved you time, a star on the repo helps other people find it.
+
+On an interactive start, a small banner says the same thing once a day. Under a container
+or systemd there is no terminal, so it never prints — the startup log line carries the
+pointer instead. Silence both with `DATAZOO_NO_BANNER=1`.
+

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,4 +1,11 @@
 #include "error.hpp"
+#include "datazoo_banner.hpp"
+
+namespace {
+// Repo identity for the issue link. Duplicated rather than shared with main.cpp
+// so error.cpp stays independent of the entry point's translation unit.
+constexpr datazoo::BannerInfo kFlapiBanner {"flapi", "", "https://github.com/DataZooDE/flapi"};
+} // namespace
 
 namespace flapi {
 
@@ -43,6 +50,11 @@ crow::json::wvalue Error::toJson() const {
     if (!details.empty()) {
         error_json["error"]["details"] = details;
     }
+
+    // A structured field rather than text appended to `message`: this payload is
+    // parsed by clients, so the link has to be additive and ignorable. Anything
+    // concatenated into the message would change what existing consumers read.
+    error_json["error"]["report_issue"] = datazoo::IssuesUrl(kFlapiBanner);
 
     return error_json;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "selfpath.hpp"
 #include "vfs_adapter.hpp"
 #include "vfs_health_checker.hpp"
+#include "datazoo_banner.hpp"
 
 using namespace flapi;
 
@@ -333,6 +334,10 @@ void signal_handler(int signal) {
         }
     }
 }
+
+// Identity for the feedback banner and the issue link on error payloads.
+static constexpr datazoo::BannerInfo kBanner {"flapi", FLAPI_VERSION,
+                                              "https://github.com/DataZooDE/flapi"};
 
 int main(int argc, char* argv[]) 
 {
@@ -644,6 +649,13 @@ int main(int argc, char* argv[])
     });
 
     CROW_LOG_INFO << "flAPI unified server started - REST API and MCP on port " << config_manager->getHttpPort();
+
+    // Once-a-day feedback nudge, at the point the server is actually up. Needs
+    // both streams to be terminals, so a container or systemd start -- how this
+    // runs in production -- prints nothing. The log line above remains the
+    // operator-facing signal.
+    datazoo::ShowBannerStandalone(kBanner);
+    CROW_LOG_INFO << datazoo::FeedbackLine(kBanner);
     
     // Print config service token prominently if enabled
     if (config_service_enabled) {

--- a/test/cpp/test_error.cpp
+++ b/test/cpp/test_error.cpp
@@ -78,6 +78,19 @@ TEST_CASE("Error::toJson", "[error]") {
         REQUIRE(json_str.find("Database") != std::string::npos);
         REQUIRE(json_str.find("Query failed") != std::string::npos);
     }
+
+    SECTION("Errors carry a report_issue link") {
+        // A structured field rather than text appended to `message`: this payload
+        // is parsed by clients, so the link has to be additive and ignorable.
+        // Concatenating it into the message would change what consumers read.
+        auto err = Error::Database("Query failed");
+        std::string json_str = err.toJson().dump();
+
+        REQUIRE(json_str.find("report_issue") != std::string::npos);
+        REQUIRE(json_str.find("github.com/DataZooDE/flapi/issues") != std::string::npos);
+        // The message itself must be untouched.
+        REQUIRE(json_str.find("\"Query failed\"") != std::string::npos);
+    }
 }
 
 TEST_CASE("Error::toHttpResponse", "[error]") {


### PR DESCRIPTION
Deployments differ in ways we cannot reproduce here, so the users who hit a problem are the only ones who can tell us what their config looked like.

Part of a fleet-wide rollout using the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule.

## Shaped around the fact that flAPI runs in a container

| Surface | When |
|---|---|
| Startup log line | **Always** — under Docker/systemd there is no terminal, so this is the one operators actually see |
| Banner | Interactive start only, both streams a TTY, once a day |
| `error.report_issue` | Every JSON error payload |

## The error link is a structured field, not appended text

```json
{"success": false, "error": {"category": "Database", "message": "Query failed",
                             "report_issue": "https://github.com/DataZooDE/flapi/issues"}}
```

This payload is **parsed by clients**, so the link has to be additive and ignorable. Concatenating it into `message` would change what existing consumers read — the same reasoning that left erpl-adt's `--json` output untouched while its human-readable errors got the footer.

`test_error.cpp` gains a section asserting both halves: the field is present **and** the message is unchanged.

## Verified on the built binary

- Interactive start shows the banner + log line; correctly advertises only `DATAZOO_NO_BANNER=1` (no `SET` outside DuckDB)
- **Piped start: zero banner output**, log line still present
- **6131 assertions in 645 cases pass**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/flapi/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788621235&installation_model_id=425457&pr_number=105&repository=DataZooDE%2Fflapi&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fflapi%2Fpull%2F105&signature=2de8fef44d97b804ebbf302869297aee997963f04229ce369da7ebff4e30f806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->