### PR TITLE
chore: Bump DuckDB to v1.5.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - ~13,400 lines of C++ code across 54 files
 - Supports Linux (x86/ARM64), macOS (Intel/Apple Silicon), and Windows
 - Declarative API philosophy: logic lives in YAML/SQL, not compiled code
-- Single binary deployment with built-in DuckDB 1.5.3
+- Single binary deployment with built-in DuckDB 1.5.5
 
 ## Architecture Documentation
 
@@ -679,7 +679,7 @@ make integration-test-ci           # Full suite with server management
 
 ### DuckDB Integration
 
-- Embedded in-process OLAP database (v1.5.3)
+- Embedded in-process OLAP database (v1.5.5)
 - Extensions for external data sources: BigQuery, Postgres, Iceberg, Parquet, CSV
 - Query execution with result caching
 
@@ -1206,7 +1206,7 @@ Common extensions:
 
 | Library | Purpose |
 |---------|---------|
-| **DuckDB 1.5.3** | In-process OLAP database |
+| **DuckDB 1.5.5** | In-process OLAP database |
 | **Crow** | C++ web framework |
 | **OpenSSL** | Encryption/security |
 | **jwt-cpp** | JWT authentication |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Windows-specific settings
 if(WIN32)
-    # Use static runtime libraries for Windows builds (/MT, matching DuckDB 1.5.3)
+    # Use static runtime libraries for Windows builds (/MT, matching DuckDB 1.5.5)
     add_definitions(-D_WIN32_WINNT=0x0601)  # Target Windows 7 or later
 
     # Set vcpkg triplet for Windows
@@ -17,8 +17,8 @@ if(WIN32)
         endif()
     endif()
 
-    # Force static CRT (/MT) to match DuckDB 1.5.3's unconditional
-    # set(CMAKE_MSVC_RUNTIME_LIBRARY ...) in duckdb/CMakeLists.txt:39.
+    # Force static CRT (/MT) to match DuckDB 1.5.5's unconditional
+    # set(CMAKE_MSVC_RUNTIME_LIBRARY ...) in duckdb/CMakeLists.txt:62.
     # vcpkg's toolchain only sets /MT for packages; flapi's own targets need
     # this explicit setting or MSVC defaults to /MD → LNK2038 at link time.
     if(NOT MINGW)
@@ -220,7 +220,7 @@ find_package(zstd CONFIG REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
 
 # Add DuckDB
-set(DUCKDB_EXPLICIT_VERSION 1.5.3)
+set(DUCKDB_EXPLICIT_VERSION 1.5.5)
 set(ENABLE_EXTENSION_AUTOLOADING true)
 set(ENABLE_EXTENSION_AUTOINSTALL true)
 if (WIN32)

--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ The easiest way to get started with flAPI is to use the pre-built docker image.
 ```
 
 
-The image is pretty small and mainly contains the flAPI binary which is statically linked against [DuckDB v1.5.3](https://github.com/duckdb/duckdb/releases/tag/v1.5.3). Details about the docker image can be found in the [Dockerfile](./docker/development/Dockerfile).
+The image is pretty small and mainly contains the flAPI binary which is statically linked against [DuckDB v1.5.5](https://github.com/duckdb/duckdb/releases/tag/v1.5.5). Details about the docker image can be found in the [Dockerfile](./docker/development/Dockerfile).
 
 #### 2. Run flAPI:
 Once you have downloaded the binary, you can run flAPI by executing the following command:

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0.0
 **flAPI Version:** >= 1.0.0
-**DuckDB Version:** >= 1.5.3
+**DuckDB Version:** >= 1.5.5
 
 This document provides a complete reference for all configuration options in flAPI, the SQL-to-API framework that generates REST APIs and MCP tools from SQL templates.
 

--- a/src/include/duckdb_raii.hpp
+++ b/src/include/duckdb_raii.hpp
@@ -85,15 +85,15 @@ public:
     /**
      * Default constructor: creates an uninitialized result.
      */
-    DuckDBResult() noexcept : has_result_(false) {}
+    DuckDBResult() noexcept : result_{}, has_result_(false) {}
 
     /**
-     * Destructor: automatically destroys the result if initialized.
+     * Destructor: always destroys the result. duckdb_query populates the
+     * struct even on failure (error data must be freed), and
+     * duckdb_destroy_result is safe on a zero-initialized struct.
      */
     ~DuckDBResult() {
-        if (has_result_) {
-            duckdb_destroy_result(&result_);
-        }
+        duckdb_destroy_result(&result_);
     }
 
     // Delete copy constructor and assignment operator
@@ -104,11 +104,9 @@ public:
      * Move constructor: transfers ownership.
      */
     DuckDBResult(DuckDBResult&& other) noexcept
-        : has_result_(other.has_result_) {
-        if (other.has_result_) {
-            result_ = other.result_;
-            other.has_result_ = false;
-        }
+        : result_(other.result_), has_result_(other.has_result_) {
+        other.result_ = {};
+        other.has_result_ = false;
     }
 
     /**
@@ -116,14 +114,11 @@ public:
      */
     DuckDBResult& operator=(DuckDBResult&& other) noexcept {
         if (this != &other) {
-            if (has_result_) {
-                duckdb_destroy_result(&result_);
-            }
+            duckdb_destroy_result(&result_);
+            result_ = other.result_;
             has_result_ = other.has_result_;
-            if (other.has_result_) {
-                result_ = other.result_;
-                other.has_result_ = false;
-            }
+            other.result_ = {};
+            other.has_result_ = false;
         }
         return *this;
     }
@@ -153,10 +148,8 @@ public:
      * Reset the result state (manually destroy if initialized and mark as uninitialized).
      */
     void reset() {
-        if (has_result_) {
-            duckdb_destroy_result(&result_);
-            has_result_ = false;
-        }
+        duckdb_destroy_result(&result_);
+        has_result_ = false;
     }
 
 private:


### PR DESCRIPTION
## Summary
- Bump the vendored DuckDB submodule from v1.5.3 to v1.5.5 (`DUCKDB_EXPLICIT_VERSION`, docs, and the MSVC-runtime comment reference updated alongside)
- Fix a leak in the `DuckDBResult` RAII wrapper: `duckdb_query` populates the result struct even on failure and it must always be passed to `duckdb_destroy_result`; v1.5.5's richer `ErrorData` on the error path made ASAN flag this in `DuckDBResult RAII_test`
- All runtime-autoloaded extensions verified available for v1.5.5: core repo (httpfs, ducklake, fts, json, postgres, sqlite, parquet), community `bigquery`, and `erpl` from get.erpl.io

## Test plan
- [x] `make debug` builds cleanly against v1.5.5 (no internal-API breakage in embed-fs / vfs_adapter / credential_manager)
- [x] Full C++ unit suite: 644/645 pass; the one failure was the pre-existing RAII leak, fixed here (44 DuckDB-related tests re-run green after the fix)
- [x] Server startup with `examples/flapi.yaml`: logs DuckDB 1.5.5, extensions autoload without warnings, authenticated `GET /customers/` returns data
- [ ] CI matrix (Linux amd64/arm64, macOS, Windows) — note ccache is cold for this PR, expect long builds

Note for local dev: a stale `~/.duckdb/extensions/v1.5.5` cache with erpl sub-extensions extracted by an older build causes a metadata-mismatch crash at startup — delete `~/.duckdb/extensions/v1.5.5/linux_amd64/erpl*` and let it re-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/flapi/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790691964&installation_model_id=425457&pr_number=106&repository=DataZooDE%2Fflapi&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fflapi%2Fpull%2F106&signature=c5315154d1dff59c2b23c4d2ff91b33078a5881ff1332c2789f9d1476e4fcdf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->